### PR TITLE
Reproducer for vladmihalcea/hibernate-types#27

### DIFF
--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/json/PostgreSQLJsonBinaryTypeUnionTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/json/PostgreSQLJsonBinaryTypeUnionTest.java
@@ -1,0 +1,58 @@
+package com.vladmihalcea.hibernate.type.json;
+
+import com.vladmihalcea.hibernate.type.model.BaseEntity;
+import com.vladmihalcea.hibernate.type.model.Location;
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+public class PostgreSQLJsonBinaryTypeUnionTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class[] {
+                Base.class,
+                Sub1.class,
+                Sub2.class
+        };
+    }
+
+    @Test
+    public void testUnionFetch() {
+        doInJPA(em -> {
+            em.createQuery("SELECT a FROM Base a", Base.class).getResultList();
+        });
+    }
+
+    @Entity(name = "Base")
+    @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+    public static abstract class Base extends BaseEntity {
+
+    }
+
+    @Entity
+    public static abstract class Sub1 extends Base {
+
+        @Type(type = "jsonb")
+        @Column(columnDefinition = "jsonb")
+        private Location location;
+
+        public Location getLocation() {
+            return location;
+        }
+
+        public void setLocation(Location location) {
+            this.location = location;
+        }
+
+    }
+
+    @Entity
+    public static abstract class Sub2 extends Base {}
+
+}


### PR DESCRIPTION
Reproducer for #27 Exception UNION could not convert type for inheritance hierarchies with `JsonStringType`

Suggested fix was provided in https://github.com/vladmihalcea/hibernate-types/pull/28

Stacktrace:

```
javax.persistence.PersistenceException: org.hibernate.exception.SQLGrammarException: could not extract ResultSet

	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:154)
	at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:181)
	at org.hibernate.query.internal.AbstractProducedQuery.list(AbstractProducedQuery.java:1514)
	at org.hibernate.query.Query.getResultList(Query.java:135)
	at com.vladmihalcea.hibernate.type.json.PostgreSQLJsonBinaryTypeUnionTest.lambda$testUnionFetch$0(PostgreSQLJsonBinaryTypeUnionTest.java:28)
	at com.vladmihalcea.hibernate.type.util.AbstractTest.doInJPA(AbstractTest.java:452)
	at com.vladmihalcea.hibernate.type.json.PostgreSQLJsonBinaryTypeUnionTest.testUnionFetch(PostgreSQLJsonBinaryTypeUnionTest.java:27)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:44)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:41)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:20)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:28)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:31)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:76)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:193)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:52)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:191)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:42)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:184)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:236)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:157)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: org.hibernate.exception.SQLGrammarException: could not extract ResultSet
	at org.hibernate.exception.internal.SQLStateConversionDelegate.convert(SQLStateConversionDelegate.java:106)
	at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:42)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:113)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:99)
	at org.hibernate.engine.jdbc.internal.ResultSetReturnImpl.extract(ResultSetReturnImpl.java:69)
	at org.hibernate.loader.Loader.getResultSet(Loader.java:2167)
	at org.hibernate.loader.Loader.executeQueryStatement(Loader.java:1930)
	at org.hibernate.loader.Loader.executeQueryStatement(Loader.java:1892)
	at org.hibernate.loader.Loader.doQuery(Loader.java:937)
	at org.hibernate.loader.Loader.doQueryAndInitializeNonLazyCollections(Loader.java:340)
	at org.hibernate.loader.Loader.doList(Loader.java:2689)
	at org.hibernate.loader.Loader.doList(Loader.java:2672)
	at org.hibernate.loader.Loader.listIgnoreQueryCache(Loader.java:2506)
	at org.hibernate.loader.Loader.list(Loader.java:2501)
	at org.hibernate.loader.hql.QueryLoader.list(QueryLoader.java:504)
	at org.hibernate.hql.internal.ast.QueryTranslatorImpl.list(QueryTranslatorImpl.java:395)
	at org.hibernate.engine.query.spi.HQLQueryPlan.performList(HQLQueryPlan.java:220)
	at org.hibernate.internal.SessionImpl.list(SessionImpl.java:1508)
	at org.hibernate.query.internal.AbstractProducedQuery.doList(AbstractProducedQuery.java:1537)
	at org.hibernate.query.internal.AbstractProducedQuery.list(AbstractProducedQuery.java:1505)
	... 27 more
Caused by: org.postgresql.util.PSQLException: ERROR: UNION could not convert type uuid to jsonb
  Position: 264
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2182)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1911)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:173)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:615)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:465)
	at org.postgresql.jdbc2.AbstractJdbc2Statement.executeQuery(AbstractJdbc2Statement.java:350)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.ttddyy.dsproxy.proxy.PreparedStatementProxyLogic.invoke(PreparedStatementProxyLogic.java:171)
	at net.ttddyy.dsproxy.proxy.jdk.PreparedStatementInvocationHandler.invoke(PreparedStatementInvocationHandler.java:32)
	at com.sun.proxy.$Proxy25.executeQuery(Unknown Source)
	at org.hibernate.engine.jdbc.internal.ResultSetReturnImpl.extract(ResultSetReturnImpl.java:60)
	... 42 more
```