### PR TITLE
Fix Typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you are using JSON Types, then you might be interested in setting the followi
 </dependency>
 ````
 
-###### Hibernate 5,5, 5.5, 5.4, 5.3, and 5.2
+###### Hibernate 5.6, 5.5, 5.4, 5.3, and 5.2
 
 ````xml
 <dependency>


### PR DESCRIPTION
I fix a typo in the README where in the `JSON Optional Maven Dependencies` -> `Hibernate` section there was an `5,5` instead of `5.6`