### PR TITLE
Correct minor typo in HibernateRepository

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Depending on the Hibernate version you are using, you need to add the following 
     <dependency>
         <groupId>io.hypersistence</groupId>
         <artifactId>hypersistence-utils-hibernate-60</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.0</version>
     </dependency>
 
 #### Hibernate 5.6 and 5.5
@@ -39,7 +39,7 @@ Depending on the Hibernate version you are using, you need to add the following 
     <dependency>
         <groupId>io.hypersistence</groupId>
         <artifactId>hypersistence-utils-hibernate-55</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.0</version>
     </dependency>
 
 #### Hibernate 5.4, 5.3 and 5.2
@@ -47,7 +47,7 @@ Depending on the Hibernate version you are using, you need to add the following 
     <dependency>
         <groupId>io.hypersistence</groupId>
         <artifactId>hypersistence-utils-hibernate-52</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.0</version>
     </dependency>
 
 #### Hibernate 5.1 and 5.0
@@ -55,7 +55,7 @@ Depending on the Hibernate version you are using, you need to add the following 
     <dependency>
         <groupId>io.hypersistence</groupId>
         <artifactId>hypersistence-utils-hibernate-5</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.0</version>
     </dependency>
 
 #### Optional Maven Dependencies

--- a/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
+++ b/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
@@ -79,7 +79,7 @@ public interface BaseJpaRepository<T, ID> extends Repository<T, ID>, QueryByExam
      * @param <S>    entity type
      * @return entities
      */
-    <S extends T> List<S> peristAllAndFlush(Iterable<S> entities);
+    <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
      * The persist method allows you to pass the provided entity to the {@code merge} method of the

--- a/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepositoryImpl.java
+++ b/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepositoryImpl.java
@@ -51,7 +51,7 @@ public class BaseJpaRepositoryImpl<T, ID> extends SimpleJpaRepository<T, ID>
         return result;
     }
 
-    public <S extends T> List<S> peristAllAndFlush(Iterable<S> entities) {
+    public <S extends T> List<S> persistAllAndFlush(Iterable<S> entities) {
         return executeBatch(() -> {
             List<S> result = new ArrayList<>();
             for(S entity : entities) {

--- a/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
+++ b/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
@@ -97,7 +97,7 @@ public interface HibernateRepository<T> {
      * @param <S>    entity type
      * @return entities
      */
-    <S extends T> List<S> peristAllAndFlush(Iterable<S> entities);
+    <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
      * The persist method allows you to pass the provided entity to the {@code merge} method of the

--- a/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepositoryImpl.java
+++ b/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepositoryImpl.java
@@ -65,7 +65,7 @@ public class HibernateRepositoryImpl<T> implements HibernateRepository<T> {
         return result;
     }
 
-    public <S extends T> List<S> peristAllAndFlush(Iterable<S> entities) {
+    public <S extends T> List<S> persistAllAndFlush(Iterable<S> entities) {
         return executeBatch(() -> {
             List<S> result = new ArrayList<>();
             for(S entity : entities) {

--- a/hypersistence-utils-hibernate-52/src/test/java/io/hypersistence/utils/spring/repo/base/SpringDataJPABaseTest.java
+++ b/hypersistence-utils-hibernate-52/src/test/java/io/hypersistence/utils/spring/repo/base/SpringDataJPABaseTest.java
@@ -60,7 +60,7 @@ public class SpringDataJPABaseTest {
                     .setSlug("hypersistence-optimizer")
             );
 
-            postRepository.peristAllAndFlush(
+            postRepository.persistAllAndFlush(
                 LongStream.range(3, 1000)
                     .mapToObj(i -> new Post()
                         .setId(i)

--- a/hypersistence-utils-hibernate-52/src/test/java/io/hypersistence/utils/spring/repo/hibernate/SpringDataJPAHibernateTest.java
+++ b/hypersistence-utils-hibernate-52/src/test/java/io/hypersistence/utils/spring/repo/hibernate/SpringDataJPAHibernateTest.java
@@ -56,7 +56,7 @@ public class SpringDataJPAHibernateTest {
                     .setSlug("hypersistence-optimizer")
             );
 
-            postRepository.peristAllAndFlush(
+            postRepository.persistAllAndFlush(
                 LongStream.range(3, 1000)
                     .mapToObj(i -> new Post()
                         .setId(i)

--- a/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
+++ b/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
@@ -79,7 +79,7 @@ public interface BaseJpaRepository<T, ID> extends Repository<T, ID>, QueryByExam
      * @param <S>    entity type
      * @return entities
      */
-    <S extends T> List<S> peristAllAndFlush(Iterable<S> entities);
+    <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
      * The persist method allows you to pass the provided entity to the {@code merge} method of the

--- a/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepositoryImpl.java
+++ b/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepositoryImpl.java
@@ -52,7 +52,7 @@ public class BaseJpaRepositoryImpl<T, ID> extends SimpleJpaRepository<T, ID>
         return result;
     }
 
-    public <S extends T> List<S> peristAllAndFlush(Iterable<S> entities) {
+    public <S extends T> List<S> persistAllAndFlush(Iterable<S> entities) {
         return executeBatch(() -> {
             List<S> result = new ArrayList<>();
             for(S entity : entities) {

--- a/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
+++ b/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
@@ -97,7 +97,7 @@ public interface HibernateRepository<T> {
      * @param <S>    entity type
      * @return entities
      */
-    <S extends T> List<S> peristAllAndFlush(Iterable<S> entities);
+    <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
      * The persist method allows you to pass the provided entity to the {@code merge} method of the

--- a/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepositoryImpl.java
+++ b/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepositoryImpl.java
@@ -65,7 +65,7 @@ public class HibernateRepositoryImpl<T> implements HibernateRepository<T> {
         return result;
     }
 
-    public <S extends T> List<S> peristAllAndFlush(Iterable<S> entities) {
+    public <S extends T> List<S> persistAllAndFlush(Iterable<S> entities) {
         return executeBatch(() -> {
             List<S> result = new ArrayList<>();
             for(S entity : entities) {

--- a/hypersistence-utils-hibernate-55/src/test/java/io/hypersistence/utils/spring/repo/base/SpringDataJPABaseTest.java
+++ b/hypersistence-utils-hibernate-55/src/test/java/io/hypersistence/utils/spring/repo/base/SpringDataJPABaseTest.java
@@ -60,7 +60,7 @@ public class SpringDataJPABaseTest {
                     .setSlug("hypersistence-optimizer")
             );
 
-            postRepository.peristAllAndFlush(
+            postRepository.persistAllAndFlush(
                 LongStream.range(3, 1000)
                     .mapToObj(i -> new Post()
                         .setId(i)

--- a/hypersistence-utils-hibernate-55/src/test/java/io/hypersistence/utils/spring/repo/hibernate/SpringDataJPAHibernateTest.java
+++ b/hypersistence-utils-hibernate-55/src/test/java/io/hypersistence/utils/spring/repo/hibernate/SpringDataJPAHibernateTest.java
@@ -57,7 +57,7 @@ public class SpringDataJPAHibernateTest {
                     .setSlug("hypersistence-optimizer")
             );
 
-            postRepository.peristAllAndFlush(
+            postRepository.persistAllAndFlush(
                 LongStream.range(3, 1000)
                     .mapToObj(i -> new Post()
                         .setId(i)

--- a/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
+++ b/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
@@ -79,7 +79,7 @@ public interface BaseJpaRepository<T, ID> extends Repository<T, ID>, QueryByExam
      * @param <S>    entity type
      * @return entities
      */
-    <S extends T> List<S> peristAllAndFlush(Iterable<S> entities);
+    <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
      * The persist method allows you to pass the provided entity to the {@code merge} method of the

--- a/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepositoryImpl.java
+++ b/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepositoryImpl.java
@@ -47,7 +47,7 @@ public class BaseJpaRepositoryImpl<T, ID> extends SimpleJpaRepository<T, ID>
         return result;
     }
 
-    public <S extends T> List<S> peristAllAndFlush(Iterable<S> entities) {
+    public <S extends T> List<S> persistAllAndFlush(Iterable<S> entities) {
         return executeBatch(() -> {
             List<S> result = new ArrayList<>();
             for(S entity : entities) {

--- a/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
+++ b/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
@@ -97,7 +97,7 @@ public interface HibernateRepository<T> {
      * @param <S>    entity type
      * @return entities
      */
-    <S extends T> List<S> peristAllAndFlush(Iterable<S> entities);
+    <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
      * The persist method allows you to pass the provided entity to the {@code merge} method of the

--- a/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepositoryImpl.java
+++ b/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepositoryImpl.java
@@ -65,7 +65,7 @@ public class HibernateRepositoryImpl<T> implements HibernateRepository<T> {
         return result;
     }
 
-    public <S extends T> List<S> peristAllAndFlush(Iterable<S> entities) {
+    public <S extends T> List<S> persistAllAndFlush(Iterable<S> entities) {
         return executeBatch(() -> {
             List<S> result = new ArrayList<>();
             for(S entity : entities) {

--- a/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/spring/repo/base/SpringDataJPABaseTest.java
+++ b/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/spring/repo/base/SpringDataJPABaseTest.java
@@ -60,7 +60,7 @@ public class SpringDataJPABaseTest {
                     .setSlug("hypersistence-optimizer")
             );
 
-            postRepository.peristAllAndFlush(
+            postRepository.persistAllAndFlush(
                 LongStream.range(3, 1000)
                     .mapToObj(i -> new Post()
                         .setId(i)

--- a/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/spring/repo/hibernate/SpringDataJPAHibernateTest.java
+++ b/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/spring/repo/hibernate/SpringDataJPAHibernateTest.java
@@ -58,7 +58,7 @@ public class SpringDataJPAHibernateTest {
                     .setSlug("hypersistence-optimizer")
             );
 
-            postRepository.peristAllAndFlush(
+            postRepository.persistAllAndFlush(
                 LongStream.range(3, 1000)
                     .mapToObj(i -> new Post()
                         .setId(i)

--- a/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/spring/repo/sort/SpringDataJPABaseSortingTest.java
+++ b/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/spring/repo/sort/SpringDataJPABaseSortingTest.java
@@ -61,7 +61,7 @@ public class SpringDataJPABaseSortingTest {
                     .setSlug("hypersistence-optimizer")
             );
 
-            postRepository.peristAllAndFlush(
+            postRepository.persistAllAndFlush(
                 LongStream.range(3, 1000)
                     .mapToObj(i -> new Post()
                         .setId(i)


### PR DESCRIPTION
The interface `HibernateRepository` contains utility implementations for bulk operations: `updateAllAndFlush`, `mergeAllAndFlush`, and `peristAllAndFlush`. 

There is a typo in the latter, which should be `persistAllAndFlush`. This contribution aims to correct this typo in the least disruptive way possible. 

Please note that this will constitute a breaking change for any consumers making use of the extant method.