### PR TITLE
Unencapsulate Range utility functions

### DIFF
--- a/hypersistence-utils-hibernate-5/src/main/java/io/hypersistence/utils/hibernate/type/range/Range.java
+++ b/hypersistence-utils-hibernate-5/src/main/java/io/hypersistence/utils/hibernate/type/range/Range.java
@@ -379,7 +379,7 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
         };
     }
 
-    private boolean isBounded() {
+    public boolean isBounded() {
         return !hasMask(LOWER_INFINITE) && !hasMask(UPPER_INFINITE);
     }
 
@@ -524,12 +524,12 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
         return isBoundedOpen() && hasEqualBounds();
     }
 
-    private boolean hasEqualBounds() {
+    public boolean hasEqualBounds() {
         return lower == null && upper == null
             || lower != null && upper != null && lower.compareTo(upper) == 0;
     }
 
-    private boolean isBoundedOpen() {
+    public boolean isBoundedOpen() {
         return isBounded() && !isLowerBoundClosed() && !isUpperBoundClosed();
     }
 

--- a/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/hibernate/type/range/Range.java
+++ b/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/hibernate/type/range/Range.java
@@ -495,7 +495,7 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
         };
     }
 
-    private boolean isBounded() {
+    public boolean isBounded() {
         return !hasMask(LOWER_INFINITE) && !hasMask(UPPER_INFINITE);
     }
 
@@ -639,12 +639,12 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
         return isBoundedOpen() && hasEqualBounds();
     }
 
-    private boolean hasEqualBounds() {
+    public boolean hasEqualBounds() {
         return lower == null && upper == null
             || lower != null && upper != null && lower.compareTo(upper) == 0;
     }
 
-    private boolean isBoundedOpen() {
+    public boolean isBoundedOpen() {
         return isBounded() && !isLowerBoundClosed() && !isUpperBoundClosed();
     }
 

--- a/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/hibernate/type/range/Range.java
+++ b/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/hibernate/type/range/Range.java
@@ -495,7 +495,7 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
         };
     }
 
-    private boolean isBounded() {
+    public boolean isBounded() {
         return !hasMask(LOWER_INFINITE) && !hasMask(UPPER_INFINITE);
     }
 
@@ -639,12 +639,12 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
         return isBoundedOpen() && hasEqualBounds();
     }
 
-    private boolean hasEqualBounds() {
+    public boolean hasEqualBounds() {
         return lower == null && upper == null
             || lower != null && upper != null && lower.compareTo(upper) == 0;
     }
 
-    private boolean isBoundedOpen() {
+    public boolean isBoundedOpen() {
         return isBounded() && !isLowerBoundClosed() && !isUpperBoundClosed();
     }
 

--- a/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/range/Range.java
+++ b/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/range/Range.java
@@ -495,7 +495,7 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
         };
     }
 
-    private boolean isBounded() {
+    public boolean isBounded() {
         return !hasMask(LOWER_INFINITE) && !hasMask(UPPER_INFINITE);
     }
 
@@ -639,12 +639,12 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
         return isBoundedOpen() && hasEqualBounds();
     }
 
-    private boolean hasEqualBounds() {
+    public boolean hasEqualBounds() {
         return lower == null && upper == null
             || lower != null && upper != null && lower.compareTo(upper) == 0;
     }
 
-    private boolean isBoundedOpen() {
+    public boolean isBoundedOpen() {
         return isBounded() && !isLowerBoundClosed() && !isUpperBoundClosed();
     }
 


### PR DESCRIPTION
Unencapsulate Range bounds checking utility functions.

`Range#hasEqualBounds`
`Range#isBoundedOpen`
`Range#isBounded`