### PR TITLE
Support for Instant and OffsetDateTime

### DIFF
--- a/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/range/Range.java
+++ b/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/range/Range.java
@@ -40,6 +40,7 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
 
     public static final String INFINITY = "infinity";
 
+    // Text pattern for 'TIMESTAMP' as used by the database
     private static final DateTimeFormatter LOCAL_DATE_TIME = new DateTimeFormatterBuilder()
         .appendPattern("yyyy-MM-dd HH:mm:ss")
         .optionalStart()
@@ -48,12 +49,10 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
         .optionalEnd()
         .toFormatter();
 
-    private static final DateTimeFormatter ZONE_DATE_TIME = new DateTimeFormatterBuilder()
-        .appendPattern("yyyy-MM-dd HH:mm:ss")
-        .optionalStart()
-        .appendPattern(".")
-        .appendFraction(ChronoField.NANO_OF_SECOND, 1, 6, false)
-        .optionalEnd()
+    // Text pattern for 'TIMESTAMP WITH TIMEZONE' as used by the database when values are retrieved
+    // from the database.
+    private static final DateTimeFormatter OFFSET_DATE_TIME = new DateTimeFormatterBuilder()
+        .append(LOCAL_DATE_TIME)
         .appendOffset("+HH:mm", "Z")
         .toFormatter();
 
@@ -478,7 +477,7 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
     private static Function<String, ZonedDateTime> parseZonedDateTime() {
         return s -> {
             try {
-                return ZonedDateTime.parse(s, ZONE_DATE_TIME);
+                return ZonedDateTime.parse(s, OFFSET_DATE_TIME);
             } catch (DateTimeParseException e) {
                 return ZonedDateTime.parse(s);
             }
@@ -667,7 +666,7 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
     private Function<T, String> boundToString() {
         return t -> {
             if (clazz.equals(ZonedDateTime.class)) {
-                return ZONE_DATE_TIME.format((ZonedDateTime) t);
+                return OFFSET_DATE_TIME.format((ZonedDateTime) t);
             }
 
             return t.toString();

--- a/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/range/Range.java
+++ b/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/range/Range.java
@@ -67,7 +67,7 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
         this.mask = mask;
         this.clazz = clazz;
 
-        if (isBounded() && lower != null && upper != null && lower.compareTo(upper) > 0) {
+        if (isBounded() && lower != null && upper != null && compare(lower, upper, true) > 0) {
             throw new IllegalArgumentException("The lower bound is greater then upper!");
         }
     }
@@ -464,12 +464,92 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
         return range;
     }
 
+    /**
+     * Creates the {@code OffsetDateTime} range from provided string:
+     * <pre>{@code
+     *     Range<OffsetDateTime> closed = Range.offsetDateTimeRange("[2007-12-03T10:15:30+01:00\",\"2008-12-03T10:15:30+01:00]");
+     *     Range<OffsetDateTime> quoted = Range.offsetDateTimeRange("[\"2007-12-03T10:15:30+01:00\",\"2008-12-03T10:15:30+01:00\"]");
+     *     Range<OffsetDateTime> iso = Range.offsetDateTimeRange("[2011-12-03T10:15:30+01:00, 2012-12-03T10:15:30+01:00]");
+     * }</pre>
+     * <p>
+     * The valid formats for bounds are:
+     * <ul>
+     * <li>yyyy-MM-dd HH:mm:ss[.SSSSSS]X</li>
+     * <li>yyyy-MM-dd'T'HH:mm:ss[.SSSSSS]X</li>
+     * </ul>
+     *
+     * @param rangeStr The range string, for example {@literal "[2011-12-03T10:15:30+01:00,2012-12-03T10:15:30+01:00]"}.
+     *
+     * @return The range of {@code ZonedDateTime}s.
+     *
+     * @throws DateTimeParseException   when one of the bounds are invalid.
+     * @throws IllegalArgumentException when bounds time zones are different.
+     */
+    public static Range<OffsetDateTime> offsetDateTimeRange(String rangeStr) {
+        Range<OffsetDateTime> range = ofString(rangeStr, parseOffsetDateTime().compose(unquote()), OffsetDateTime.class);
+        if (range.hasLowerBound() && range.hasUpperBound() && !EMPTY.equals(rangeStr)) {
+            ZoneOffset lowerOffset = range.lower.getOffset();
+            ZoneOffset upperOffset = range.upper.getOffset();
+            if (!Objects.equals(lowerOffset, upperOffset)) {
+                throw new IllegalArgumentException("The upper and lower bounds must be in same time zone!");
+            }
+        }
+        return range;
+    }
+
+    /**
+     * Creates the {@code Instant} range from provided string:
+     * <pre>{@code
+     *     Range<Instant> closed1 = Range.instantRange("[2007-12-03T10:15:30Z\",\"2008-12-03T10:15:30Z]");
+     *     Range<Instant> closed2 = Range.instantRange("[2007-12-03T10:15:30+01:00\",\"2008-12-03T10:15:30+01:00]");
+     *     Range<Instant> quoted = Range.instantRange("[\"2007-12-03T10:15:30+01:00\",\"2008-12-03T10:15:30+01:00\"]");
+     *     Range<Instant> iso = Range.instantRange("[2011-12-03T10:15:30+01:00, 2012-12-03T10:15:30+01:00]");
+     * }</pre>
+     * <p>
+     * The valid formats for bounds are:
+     * <ul>
+     * <li>yyyy-MM-dd HH:mm:ss[.SSSSSS]X</li>
+     * <li>yyyy-MM-dd'T'HH:mm:ss[.SSSSSS]X</li>
+     * </ul>
+     *
+     * <p>
+     * As can be seen, for convenience, offset based string formats are supported too. This is because {@code OffsetDateTime}
+     * has a direct and unambiguous conversion to {@code Instant}.
+     *
+     * @param rangeStr The range string, for example {@literal "[2011-12-03T10:15:30+01:00,2012-12-03T10:15:30+01:00]"}.
+     * @return The range of {@code ZonedDateTime}s.
+     * @throws DateTimeParseException   when one of the bounds are invalid.
+     */
+    public static Range<Instant> instantRange(String rangeStr) {
+        return ofString(rangeStr, parseInstant().compose(unquote()), Instant.class);
+    }
+
     private static Function<String, LocalDateTime> parseLocalDateTime() {
         return s -> {
             try {
                 return LocalDateTime.parse(s, LOCAL_DATE_TIME);
             } catch (DateTimeParseException e) {
                 return LocalDateTime.parse(s);
+            }
+        };
+    }
+
+    private static Function<String, Instant> parseInstant() {
+        return s -> {
+            try {
+                return OffsetDateTime.parse(s, OFFSET_DATE_TIME).toInstant();
+            } catch (DateTimeParseException e) {
+                return OffsetDateTime.parse(s).toInstant();
+            }
+        };
+    }
+
+    private static Function<String, OffsetDateTime> parseOffsetDateTime() {
+        return s -> {
+            try {
+                return OffsetDateTime.parse(s, OFFSET_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                return OffsetDateTime.parse(s);
             }
         };
     }
@@ -512,6 +592,36 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
     @Override
     public int hashCode() {
         return Objects.hash(lower, upper, mask, clazz);
+    }
+
+    /**
+     * Indicates if another range, {@code o}, is equal to this one.
+     * This method produces the same result as method {@link #equals(Object)} except for
+     * {@code OffsetDateTime}-ranges and {@code ZonedDateTime}-ranges where this method performs
+     * comparison based on Instant equivalents, rather than comparing {@code OffsetDateTime}/{@code ZonedDateTime}
+     * directly.
+     *
+     * <p>
+     * Consider the following two OffsetDateTime or ZonedDateTime ranges:
+     * <pre>
+     *      ['2007-12-03T09:30.00Z',)
+     *      ['2007-12-03T10:30.00+01:00',)
+     * </pre>
+     *
+     * As can be seen both timestamp values refer to the same Instant in time. This method returns
+     * {@code true} for such comparison while {@link #equals(Object)} returns {@code false}.
+     *
+     *
+     * @param o other Range
+     * @return true if equal
+     */
+    public boolean equalsInValue(Range<T> o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        return mask == o.mask &&
+                (compare(lower, o.lower, true) == 0) &&
+                (compare(upper, o.upper, true) == 0) &&
+                Objects.equals(clazz, o.clazz);
     }
 
     @Override
@@ -566,6 +676,68 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
      * <p>
      * For example:
      * <pre>{@code
+     *     assertTrue(integerRange("[1,2]").contains(1, true))
+     *     assertTrue(integerRange("[1,2]").contains(2, true))
+     *     assertTrue(integerRange("[-1,1]").contains(0, true))
+     *     assertTrue(infinity(Integer.class).contains(Integer.MAX_VALUE, true))
+     *     assertTrue(infinity(Integer.class).contains(Integer.MIN_VALUE, true))
+     *
+     *     assertFalse(integerRange("(1,2]").contains(1, true))
+     *     assertFalse(integerRange("(1,2]").contains(3, true))
+     *     assertFalse(integerRange("[-1,1]").contains(0, true))
+     * }</pre>
+     *
+     * <p>
+     * <b>For {@code OffsetDateTime}-ranges and {@code ZonedDateTime}-ranges:</b> The {@code ic} parameter determines
+     * how values are compared. Consider the following two OffsetDateTime or ZonedDateTime values:
+     * <ol>
+     *     <li>'2007-12-03T09:30.00Z'</li>
+     *     <li>'2007-12-03T10:30.00+01:00'</li>
+     * </ol>
+     * As can be seen both values refer to the same instant in time. This type of jitter it likely to happen
+     * with databases: you persist the value (1) but when you later read it back from the database, it may have morphed into
+     * (2) depending on the time zone of your JVM. With standard comparison ({@code ic == false}) one of them would
+     * be evaluated as larger than the other one. This is likely to give unexpected results from this method. By contrast,
+     * if {@code ic == false}, then the two values would be evaluated as equals: none is larger or smaller than the other.
+     *
+     * It is recommended to always use {@code ic = true} when range type is {@code OffsetDateTime} or {@code ZonedDateTime}.
+     *
+     *
+     * @param point The point to check.
+     * @param ic {@code true} if comparison based on Instant values should be performed. Ignored unless
+     *                       range type is {@code OffsetDateTime} or {@code ZonedDateTime}.
+     * @return Whether {@code point} in this range or not.
+     */
+    public boolean contains(T point, boolean ic) {
+        if (isEmpty()) {
+            return false;
+        }
+
+        boolean l = hasLowerBound();
+        boolean u = hasUpperBound();
+
+        if (l && u) {
+            boolean inLower = hasMask(LOWER_INCLUSIVE) ? compare(lower, point, ic) <= 0 : compare(lower, point, ic) < 0;
+            boolean inUpper = hasMask(UPPER_INCLUSIVE) ? compare(upper, point, ic) >= 0 : compare(upper, point, ic)> 0;
+
+            return inLower && inUpper;
+        } else if (l) {
+            return hasMask(LOWER_INCLUSIVE) ? compare(lower, point, ic)<= 0 : compare(lower, point, ic) < 0;
+        } else if (u) {
+            return hasMask(UPPER_INCLUSIVE) ? compare(upper, point, ic) >= 0 : compare(upper, point, ic) > 0;
+        }
+
+        // INFINITY
+        return true;
+    }
+
+
+    /**
+     * Determines whether this range contains this point or not. This method is equivalent
+     * to {@link #contains(Comparable, boolean) contains(point, true)}-
+     * <p>
+     * For example:
+     * <pre>{@code
      *     assertTrue(integerRange("[1,2]").contains(1))
      *     assertTrue(integerRange("[1,2]").contains(2))
      *     assertTrue(integerRange("[-1,1]").contains(0))
@@ -577,32 +749,51 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
      *     assertFalse(integerRange("[-1,1]").contains(0))
      * }</pre>
      *
-     * @param point The point to check.
+     * <p>
+     * For ranges of type {@code OffsetDateTime} or {@code ZonedDateTime} you probably
+     * want to use method {@link #contains(Comparable, boolean) contains(point, true)} instead.
      *
+     * @see #contains(Comparable, boolean)
+     * @param point The point to check.
      * @return Whether {@code point} in this range or not.
      */
     public boolean contains(T point) {
-        if (isEmpty()) {
-            return false;
-        }
-
-        boolean l = hasLowerBound();
-        boolean u = hasUpperBound();
-
-        if (l && u) {
-            boolean inLower = hasMask(LOWER_INCLUSIVE) ? lower.compareTo(point) <= 0 : lower.compareTo(point) < 0;
-            boolean inUpper = hasMask(UPPER_INCLUSIVE) ? upper.compareTo(point) >= 0 : upper.compareTo(point) > 0;
-
-            return inLower && inUpper;
-        } else if (l) {
-            return hasMask(LOWER_INCLUSIVE) ? lower.compareTo(point) <= 0 : lower.compareTo(point) < 0;
-        } else if (u) {
-            return hasMask(UPPER_INCLUSIVE) ? upper.compareTo(point) >= 0 : upper.compareTo(point) > 0;
-        }
-
-        // INFINITY
-        return true;
+        return contains(point, false);
     }
+
+    private int compare(T t1, T t2, boolean instantComparison) {
+
+        if (instantComparison) {
+            if (t1 instanceof OffsetDateTime && t2 instanceof OffsetDateTime) {
+                OffsetDateTime t1x = (OffsetDateTime) t1;
+                OffsetDateTime t2x = (OffsetDateTime) t2;
+                if (t1x.isEqual(t2x)) {
+                    return 0;
+                }
+                if (t1x.isBefore(t2x)) {
+                    return -1;
+                }
+                if (t1x.isAfter(t2x)) {
+                    return 1;
+                }
+            }
+            if (t1 instanceof ZonedDateTime && t2 instanceof ZonedDateTime) {
+                ZonedDateTime t1x = (ZonedDateTime) t1;
+                ZonedDateTime t2x = (ZonedDateTime) t2;
+                if (t1x.isEqual(t2x)) {
+                    return 0;
+                }
+                if (t1x.isBefore(t2x)) {
+                    return -1;
+                }
+                if (t1x.isAfter(t2x)) {
+                    return 1;
+                }
+            }
+        }
+        return t1.compareTo(t2);
+    }
+
 
     /**
      * Determines whether this range contains this range or not.
@@ -617,11 +808,10 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
      * }</pre>
      *
      * @param range The range to check.
-     *
      * @return Whether {@code range} in this range or not.
      */
     public boolean contains(Range<T> range) {
-        return !isEmpty() && (!range.hasLowerBound() || contains(range.lower)) && (!range.hasUpperBound() || contains(range.upper));
+        return !isEmpty() && (!range.hasLowerBound() || contains(range.lower, true)) && (!range.hasUpperBound() || contains(range.upper, true));
     }
 
     /**
@@ -640,7 +830,7 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
 
     public boolean hasEqualBounds() {
         return lower == null && upper == null
-            || lower != null && upper != null && lower.compareTo(upper) == 0;
+            || lower != null && upper != null && compare(lower, upper, true) == 0;
     }
 
     public boolean isBoundedOpen() {
@@ -666,7 +856,15 @@ public final class Range<T extends Comparable<? super T>> implements Serializabl
     private Function<T, String> boundToString() {
         return t -> {
             if (clazz.equals(ZonedDateTime.class)) {
-                return OFFSET_DATE_TIME.format((ZonedDateTime) t);
+                // Let Java do the conversion from ZonedDateTime to OffsetDateTime.
+                // (For PostgreSQL: we could let database do the conversion instead, but better let Java handle it)
+                return OFFSET_DATE_TIME.format(((ZonedDateTime) t).toOffsetDateTime());
+            }
+            if (clazz.equals(OffsetDateTime.class)) {
+                return OFFSET_DATE_TIME.format((OffsetDateTime) t);
+            }
+            if (clazz.equals(Instant.class)) {
+                return OFFSET_DATE_TIME.format(((Instant) t).atOffset(ZoneOffset.UTC));
             }
 
             return t.toString();

--- a/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/type/range/PostgreSQLRangeTypeTest.java
+++ b/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/type/range/PostgreSQLRangeTypeTest.java
@@ -6,13 +6,9 @@ import org.hibernate.annotations.Type;
 import org.junit.Test;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.*;
 
-import static io.hypersistence.utils.hibernate.type.range.Range.infinite;
-import static io.hypersistence.utils.hibernate.type.range.Range.zonedDateTimeRange;
+import static io.hypersistence.utils.hibernate.type.range.Range.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -33,7 +29,11 @@ public class PostgreSQLRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
 
     private final Range<LocalDateTime> localDateTimeRange = Range.localDateTimeRange("[2014-04-28 16:00:49,2015-04-28 16:00:49]");
 
-    private final Range<ZonedDateTime> tsTz = zonedDateTimeRange("[\"2007-12-03T10:15:30+01:00\",\"2008-12-03T10:15:30+01:00\"]");
+    private final Range<ZonedDateTime> tsTzZdt = zonedDateTimeRange("[\"2007-12-03T10:15:30+01:00\",\"2008-12-03T10:15:30+01:00\"]");
+
+    private final Range<Instant> tsTzIns = instantRange("[\"2007-12-03T10:15:30+01:00\",\"2008-12-03T10:15:30+01:00\"]");
+
+    private final Range<OffsetDateTime> tsTzOdt = offsetDateTimeRange("[\"2007-12-03T10:15:30+01:00\",\"2008-12-03T10:15:30+01:00\"]");
 
     private final Range<ZonedDateTime> tsTzEmpty = zonedDateTimeRange("empty");
 
@@ -60,7 +60,9 @@ public class PostgreSQLRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
             restriction.setRangeLong(int8Range);
             restriction.setRangeBigDecimal(numeric);
             restriction.setRangeLocalDateTime(localDateTimeRange);
-            restriction.setRangeZonedDateTime(tsTz);
+            restriction.setRangeZonedDateTime(tsTzZdt);
+            restriction.setRangeInstant(tsTzIns);
+            restriction.setRangeOffsetDateTime(tsTzOdt);
             restriction.setRangeZonedDateTimeInfinity(infinityTsTz);
             restriction.setRangeZonedDateTimeEmpty(tsTzEmpty);
             restriction.setRangeLocalDate(dateRange);
@@ -82,12 +84,14 @@ public class PostgreSQLRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
 
             ZoneId zone = restriction.getRangeZonedDateTime().lower().getZone();
 
-            ZonedDateTime lower = tsTz.lower().withZoneSameInstant(zone);
-            ZonedDateTime upper = tsTz.upper().withZoneSameInstant(zone);
+            ZonedDateTime lower = tsTzZdt.lower().withZoneSameInstant(zone);
+            ZonedDateTime upper = tsTzZdt.upper().withZoneSameInstant(zone);
             assertEquals(restriction.getRangeZonedDateTime(), Range.closed(lower, upper));
 
             lower = infinityTsTz.lower().withZoneSameInstant(zone);
             assertEquals(restriction.getRangeZonedDateTimeInfinity(), Range.closedInfinite(lower));
+
+
         });
     }
 
@@ -149,8 +153,16 @@ public class PostgreSQLRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
         private Range<LocalDateTime> rangeLocalDateTime;
 
         @Type(PostgreSQLRangeType.class)
-        @Column(name = "r_ts_tz", columnDefinition = "tstzrange")
+        @Column(name = "r_ts_tz_zdt", columnDefinition = "tstzrange")
         private Range<ZonedDateTime> rangeZonedDateTime;
+
+        @Type(PostgreSQLRangeType.class)
+        @Column(name = "r_ts_tz_ins", columnDefinition = "tstzrange")
+        private Range<Instant> rangeInstant;
+
+        @Type(PostgreSQLRangeType.class)
+        @Column(name = "r_ts_tz_odt", columnDefinition = "tstzrange")
+        private Range<OffsetDateTime> rangeOffsetDateTime;
 
         @Type(PostgreSQLRangeType.class)
         @Column(name = "r_ts_tz_infinity", columnDefinition = "tstzrange")
@@ -222,6 +234,22 @@ public class PostgreSQLRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
 
         public void setRangeZonedDateTime(Range<ZonedDateTime> rangeZonedDateTime) {
             this.rangeZonedDateTime = rangeZonedDateTime;
+        }
+
+        public Range<Instant> getRangeInstant() {
+            return rangeInstant;
+        }
+
+        public void setRangeInstant(Range<Instant> rangeInstant) {
+            this.rangeInstant = rangeInstant;
+        }
+
+        public Range<OffsetDateTime> getRangeOffsetDateTime() {
+            return rangeOffsetDateTime;
+        }
+
+        public void setRangeOffsetDateTime(Range<OffsetDateTime> rangeOffsetDateTime) {
+            this.rangeOffsetDateTime = rangeOffsetDateTime;
         }
 
         public Range<ZonedDateTime> getRangeZonedDateTimeInfinity() {

--- a/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/type/range/RangeTest.java
+++ b/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/type/range/RangeTest.java
@@ -85,6 +85,27 @@ public class RangeTest {
     	assertNotNull(Range.zonedDateTimeRange("[2019-03-27 16:33:10.123456-06,infinity)"));
     }
 
+    public void instantTest() {
+        assertNotNull(Range.instantRange("[2019-03-27 16:33:10.1-06,)"));
+        assertNotNull(Range.instantRange("[2019-03-27 16:33:10.12-06,)"));
+        assertNotNull(Range.instantRange("[2019-03-27 16:33:10.123-06,)"));
+        assertNotNull(Range.instantRange("[2019-03-27 16:33:10.1234-06,)"));
+        assertNotNull(Range.instantRange("[2019-03-27 16:33:10.12345-06,)"));
+        assertNotNull(Range.instantRange("[2019-03-27 16:33:10.123456-06,)"));
+        assertNotNull(Range.instantRange("[2019-03-27 16:33:10.123456+05:30,)"));
+        assertNotNull(Range.instantRange("[2019-03-27 16:33:10.123456-06,infinity)"));
+    }
+
+    public void offsetDateTimeTest() {
+        assertNotNull(Range.offsetDateTimeRange("[2019-03-27 16:33:10.1-06,)"));
+        assertNotNull(Range.offsetDateTimeRange("[2019-03-27 16:33:10.12-06,)"));
+        assertNotNull(Range.offsetDateTimeRange("[2019-03-27 16:33:10.123-06,)"));
+        assertNotNull(Range.offsetDateTimeRange("[2019-03-27 16:33:10.1234-06,)"));
+        assertNotNull(Range.offsetDateTimeRange("[2019-03-27 16:33:10.12345-06,)"));
+        assertNotNull(Range.offsetDateTimeRange("[2019-03-27 16:33:10.123456-06,)"));
+        assertNotNull(Range.offsetDateTimeRange("[2019-03-27 16:33:10.123456+05:30,)"));
+        assertNotNull(Range.offsetDateTimeRange("[2019-03-27 16:33:10.123456-06,infinity)"));
+    }
 
     @Test
     public void emptyInfinityEquality() {


### PR DESCRIPTION
## Support for `Range<Instant>` and `Range<OffsetDateTime>`
Support for additional Java range types is added as per the text in bold in table below. 

Supported PostgreSQL types:

| PostgreSQL column type | Java type |
| ----- | -------- |
| `int4range`   | `Range<Integer>` |
| `int8range`   | `Range<Long>` |
| `numrange`   | `Range<BigDecimal>` |
| `tsrange`   | `Range<LocalDateTime>` |
| `tstzrange`   | `Range<ZonedDateTime>`, **`Range<OffsetDateTime>` or `Range<Instant>`** |
| `daterange`   | `Range<LocalDate>` |

The change is fully backwards compatible.

Fixes Issue #288  and Issue #96.


## Support for Instant-based comparison

Comparison functionality which can check for "functionally equivalent" has been added. With the existing "strict comparison" the following two ranges:

```text
     x1 : ['2007-12-03T09:30.00Z',)
     x2 : ['2007-12-03T10:30.00+01:00',)
```
is seen as two completely different ranges and `contains()` produces unexpected results in that the `2007-12-03T09:30.00Z` Instant is not contained in the x2 range. (see Issue #655)

This PR adds new methods which performs Instant-based comparison where applicable, meaning for types `OffsetDateTime` and `ZonedDateTime`. Fixes Issue #655.

I don't see why not any application would want to always do `contains(x, true)` going forward, but I didn't dare break backward compatibility. Hence the new feature is purely opt-in based.  There is probably a slight performance degradation by performing Instant-based comparison instead of strict comparison, but I doubt it is truly measurable.

