### PR TITLE
Return original object if target and original are the same when merging 

### DIFF
--- a/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/MutableType.java
+++ b/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/MutableType.java
@@ -127,7 +127,11 @@ public abstract class MutableType<T, JDBC extends JdbcType, JAVA extends JavaTyp
 
     @Override
     public T replace(T detached, T managed, Object owner) {
-        return deepCopy(detached);
+		if (!isMutable() || (managed != null && equals(detached, managed))) {
+			return detached;
+		}
+
+		return deepCopy(detached);
     }
 
     @Override

--- a/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/hibernate/type/json/PostgreSQLJsonTypeMergeTest.java
+++ b/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/hibernate/type/json/PostgreSQLJsonTypeMergeTest.java
@@ -1,0 +1,47 @@
+package io.hypersistence.utils.hibernate.type.json;
+
+import io.hypersistence.utils.hibernate.type.model.Event;
+import io.hypersistence.utils.hibernate.type.model.Location;
+import io.hypersistence.utils.hibernate.type.model.Participant;
+import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
+import org.junit.Test;
+
+import static java.lang.System.identityHashCode;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Simone Giusso
+ */
+public class PostgreSQLJsonTypeMergeTest extends AbstractPostgreSQLIntegrationTest {
+
+	@Override
+	protected Class<?>[] entities() {
+		return new Class<?>[]{
+				Event.class,
+				Participant.class
+		};
+	}
+
+	@Test
+	public void test() {
+		doInJPA(entityManager -> {
+			Location location = new Location();
+			location.setCountry("Romania");
+			location.setCity("Cluj-Napoca");
+
+			Event event = new Event();
+			event.setId(1L);
+			event.setLocation(location);
+			entityManager.persist(event);
+
+			event = entityManager.merge(event);
+
+			assertThatMergeReturnsTheOriginalJsonTypeObject(event.getLocation(), location);
+		});
+	}
+
+	private void assertThatMergeReturnsTheOriginalJsonTypeObject(Location target, Location original) {
+		assertEquals(identityHashCode(original), identityHashCode(target));
+	}
+
+}

--- a/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/MutableType.java
+++ b/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/MutableType.java
@@ -126,6 +126,10 @@ public abstract class MutableType<T, JDBC extends JdbcType, JAVA extends JavaTyp
 
     @Override
     public T replace(T detached, T managed, Object owner) {
+		if (!isMutable() || (managed != null && equals(detached, managed))) {
+			return detached;
+		}
+
         return deepCopy(detached);
     }
 

--- a/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/type/json/PostgreSQLJsonTypeMergeTest.java
+++ b/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/type/json/PostgreSQLJsonTypeMergeTest.java
@@ -1,0 +1,47 @@
+package io.hypersistence.utils.hibernate.type.json;
+
+import io.hypersistence.utils.hibernate.type.model.Event;
+import io.hypersistence.utils.hibernate.type.model.Location;
+import io.hypersistence.utils.hibernate.type.model.Participant;
+import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
+import org.junit.Test;
+
+import static java.lang.System.identityHashCode;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Simone Giusso
+ */
+public class PostgreSQLJsonTypeMergeTest extends AbstractPostgreSQLIntegrationTest {
+
+	@Override
+	protected Class<?>[] entities() {
+		return new Class<?>[]{
+				Event.class,
+				Participant.class
+		};
+	}
+
+	@Test
+	public void test() {
+		doInJPA(entityManager -> {
+			Location location = new Location();
+			location.setCountry("Romania");
+			location.setCity("Cluj-Napoca");
+
+			Event event = new Event();
+			event.setId(1L);
+			event.setLocation(location);
+			entityManager.persist(event);
+
+			event = entityManager.merge(event);
+
+			assertThatMergeReturnsTheOriginalJsonTypeObject(event.getLocation(), location);
+		});
+	}
+
+	private void assertThatMergeReturnsTheOriginalJsonTypeObject(Location target, Location original) {
+		assertEquals(identityHashCode(original), identityHashCode(target));
+	}
+
+}


### PR DESCRIPTION
Fix this https://github.com/vladmihalcea/hypersistence-utils/issues/677