### PR TITLE
Problem with JsonType serialization with spring-data 3.2 and hibernate 6.3

### DIFF
--- a/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/spring/domain/Movie.java
+++ b/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/spring/domain/Movie.java
@@ -1,0 +1,39 @@
+package io.hypersistence.utils.spring.domain;
+
+import com.google.common.collect.HashMultimap;
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.Type;
+
+@Entity
+@Table(
+        name = "movie"
+)
+public class Movie {
+    @Id
+    private String name;
+
+    @Type(JsonType.class)
+    @Column(columnDefinition = "json", name = "actors")
+    private HashMultimap<String, String> cast = HashMultimap.create();
+
+    public String getName() {
+        return name;
+    }
+
+    public Movie setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public Movie addCast(String role, String name) {
+        cast.put(role, name);
+        return this;
+    }
+    public HashMultimap<String, String> getCast() {
+        return cast;
+    }
+}

--- a/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/spring/repo/hibernate/JsonTypeJPATest.java
+++ b/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/spring/repo/hibernate/JsonTypeJPATest.java
@@ -1,0 +1,75 @@
+package io.hypersistence.utils.spring.repo.hibernate;
+
+import com.google.common.collect.HashMultimap;
+import io.hypersistence.utils.spring.domain.Movie;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = SpringDataJPAHibernateConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class JsonTypeJPATest {
+
+    protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Autowired
+    private MovieRepository movieRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    public void test() {
+        transactionTemplate.execute((TransactionCallback<Void>) transactionStatus -> {
+            movieRepository.persist(
+                    new Movie()
+                            .setName("No Time to Die")
+                            .addCast("actor", "Daniel Craig")
+                            .addCast("actor", "Rami Malek")
+            );
+            movieRepository.persistAndFlush(
+                    new Movie()
+                            .setName("Thunderball")
+            );
+            return null;
+        });
+
+        transactionTemplate.execute(transactionStatus -> {
+            HashMultimap<String, String> cast = HashMultimap.create();
+            cast.put("actor", "Sean Connery");
+            cast.put("actor", "Adolfo Celi");
+            movieRepository.updateActors("Thunderball", cast);
+            return null;
+        });
+
+        Optional<Movie> movie = transactionTemplate.execute(transactionStatus ->
+                movieRepository.findById("Thunderball")
+        );
+
+        assertNotNull(movie);
+        assertTrue(movie.isPresent());
+        Movie thunderball = movie.get();
+        HashMultimap<String, String> cast = thunderball.getCast();
+        assertNotNull(cast);
+        assertEquals(2, cast.size());
+    }
+}
+

--- a/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/spring/repo/hibernate/MovieRepository.java
+++ b/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/spring/repo/hibernate/MovieRepository.java
@@ -1,0 +1,18 @@
+package io.hypersistence.utils.spring.repo.hibernate;
+
+import com.google.common.collect.HashMultimap;
+import io.hypersistence.utils.spring.domain.Movie;
+import io.hypersistence.utils.spring.repository.HibernateRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MovieRepository extends HibernateRepository<Movie>, JpaRepository<Movie, String> {
+
+    @Modifying
+    @Query("UPDATE Movie m SET m.cast = :cast WHERE m.name = :name")
+    void updateActors(@Param("name") String name, @Param("cast") HashMultimap<String, String> cast);
+}


### PR DESCRIPTION
I ran into this issue while migrating my app from spring boot 2 to spring boot 3. This PR contains a test case to illustrate the problem.

There are some Entity objects with Java collection type members that map to json column in a table. They are annotated with JsonType. I noticed the tests for persisting those entities using named query were failing after migrating to spring boot 3. It looks like the code path in hibernate for handling named query is completely different from code path for persisting. It ends up doing Java serialization instead of the custom serialization for JsonType.
