### PR TITLE
Make JsonTypeDescriptor thread-safe

### DIFF
--- a/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonTypeDescriptor.java
@@ -201,10 +201,9 @@ public class JsonTypeDescriptor
                 ParameterizedType parameterizedType = (ParameterizedType) propertyType;
 
                 for(Class genericType : ReflectionUtils.getGenericTypes(parameterizedType)) {
-                    if(validatedTypes.contains(genericType)) {
+                    if(!validatedTypes.add(genericType)) {
                         continue;
                     }
-                    validatedTypes.add(genericType);
                     Method equalsMethod = ReflectionUtils.getMethodOrNull(genericType, "equals", Object.class);
                     Method hashCodeMethod = ReflectionUtils.getMethodOrNull(genericType, "hashCode");
 
@@ -219,5 +218,5 @@ public class JsonTypeDescriptor
         }
     }
 
-    private static List<Class> validatedTypes = new ArrayList<>();
+    private static final Set<Class> validatedTypes = Collections.synchronizedSet(new HashSet<>());
 }

--- a/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonTypeDescriptor.java
@@ -201,10 +201,9 @@ public class JsonTypeDescriptor
                 ParameterizedType parameterizedType = (ParameterizedType) propertyType;
 
                 for(Class genericType : ReflectionUtils.getGenericTypes(parameterizedType)) {
-                    if(validatedTypes.contains(genericType)) {
+                    if(!validatedTypes.add(genericType)) {
                         continue;
                     }
-                    validatedTypes.add(genericType);
                     Method equalsMethod = ReflectionUtils.getMethodOrNull(genericType, "equals", Object.class);
                     Method hashCodeMethod = ReflectionUtils.getMethodOrNull(genericType, "hashCode");
 
@@ -219,5 +218,5 @@ public class JsonTypeDescriptor
         }
     }
 
-    private static List<Class> validatedTypes = new ArrayList<>();
+    private static final Set<Class> validatedTypes = Collections.synchronizedSet(new HashSet<>());
 }

--- a/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJavaTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJavaTypeDescriptor.java
@@ -208,10 +208,9 @@ public class JsonJavaTypeDescriptor extends AbstractClassJavaType<Object> implem
                 ParameterizedType parameterizedType = (ParameterizedType) propertyType;
 
                 for(Class genericType : ReflectionUtils.getGenericTypes(parameterizedType)) {
-                    if(validatedTypes.contains(genericType)) {
+                    if(!validatedTypes.add(genericType)) {
                         continue;
                     }
-                    validatedTypes.add(genericType);
                     Method equalsMethod = ReflectionUtils.getMethodOrNull(genericType, "equals", Object.class);
                     Method hashCodeMethod = ReflectionUtils.getMethodOrNull(genericType, "hashCode");
 
@@ -235,5 +234,5 @@ public class JsonJavaTypeDescriptor extends AbstractClassJavaType<Object> implem
         this.jdbcType = jdbcType;
     }
 
-    private static List<Class> validatedTypes = new ArrayList<>();
+    private static final Set<Class> validatedTypes = Collections.synchronizedSet(new HashSet<>());
 }

--- a/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/hibernate/type/json/internal/JsonTypeDescriptorTest.java
+++ b/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/hibernate/type/json/internal/JsonTypeDescriptorTest.java
@@ -2,17 +2,29 @@ package io.hypersistence.utils.hibernate.type.json.internal;
 
 import io.hypersistence.utils.hibernate.type.model.BaseEntity;
 import org.hibernate.HibernateException;
+import org.hibernate.type.descriptor.WrapperOptions;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@RunWith(MockitoJUnitRunner.class)
 public class JsonTypeDescriptorTest {
+    private @Mock WrapperOptions wrapperOptions;
 
     /**
      * If JSON serialization is used,
@@ -51,6 +63,21 @@ public class JsonTypeDescriptorTest {
             fail("Should fail because the propertyType is null!");
         } catch (HibernateException expected) {
         }
+    }
+
+    @Test
+    public void testCollectionPropertyTypes() {
+        JsonJavaTypeDescriptor listDescriptor = new JsonJavaTypeDescriptor(new TestParameterizedTypeImpl(String.class, ArrayList.class));
+        JsonJavaTypeDescriptor setDescriptor = new JsonJavaTypeDescriptor(new TestParameterizedTypeImpl(String.class, HashSet.class));
+        List<String> expectedArrayListValue = new ArrayList<>();
+        expectedArrayListValue.add("one");
+        expectedArrayListValue.add("two");
+        Set<String> expectedHashSetValue = new HashSet<>();
+        expectedHashSetValue.add("one");
+        expectedHashSetValue.add("two");
+
+        assertEquals(expectedArrayListValue, listDescriptor.wrap("[\"one\",\"two\"]", wrapperOptions));
+        assertEquals(expectedHashSetValue, setDescriptor.wrap("[\"one\",\"two\"]", wrapperOptions));
     }
 
     private Form createForm(Integer... numbers) {
@@ -118,6 +145,31 @@ public class JsonTypeDescriptorTest {
         @Override
         public int hashCode() {
             return Objects.hash(formFields);
+        }
+    }
+
+    private static class TestParameterizedTypeImpl implements ParameterizedType {
+        private final Class<?> actualType;
+        private final Class<?> rawType;
+
+        public TestParameterizedTypeImpl(Class<?> actualType, Class<?> rawType) {
+            this.actualType = actualType;
+            this.rawType = rawType;
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return new Type[]{actualType};
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return null;
         }
     }
 }

--- a/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJavaTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJavaTypeDescriptor.java
@@ -208,10 +208,9 @@ public class JsonJavaTypeDescriptor extends AbstractClassJavaType<Object> implem
                 ParameterizedType parameterizedType = (ParameterizedType) propertyType;
 
                 for(Class genericType : ReflectionUtils.getGenericTypes(parameterizedType)) {
-                    if(validatedTypes.contains(genericType)) {
+                    if(!validatedTypes.add(genericType)) {
                         continue;
                     }
-                    validatedTypes.add(genericType);
                     Method equalsMethod = ReflectionUtils.getMethodOrNull(genericType, "equals", Object.class);
                     Method hashCodeMethod = ReflectionUtils.getMethodOrNull(genericType, "hashCode");
 
@@ -235,5 +234,5 @@ public class JsonJavaTypeDescriptor extends AbstractClassJavaType<Object> implem
         this.jdbcType = jdbcType;
     }
 
-    private static List<Class> validatedTypes = new ArrayList<>();
+    private static final Set<Class> validatedTypes = Collections.synchronizedSet(new HashSet<>());
 }

--- a/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/type/json/internal/JsonTypeDescriptorTest.java
+++ b/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/type/json/internal/JsonTypeDescriptorTest.java
@@ -2,17 +2,29 @@ package io.hypersistence.utils.hibernate.type.json.internal;
 
 import io.hypersistence.utils.hibernate.type.model.BaseEntity;
 import org.hibernate.HibernateException;
+import org.hibernate.type.descriptor.WrapperOptions;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@RunWith(MockitoJUnitRunner.class)
 public class JsonTypeDescriptorTest {
+    private @Mock WrapperOptions wrapperOptions;
 
     /**
      * If JSON serialization is used,
@@ -51,6 +63,21 @@ public class JsonTypeDescriptorTest {
             fail("Should fail because the propertyType is null!");
         } catch (HibernateException expected) {
         }
+    }
+
+    @Test
+    public void testCollectionPropertyTypes() {
+        JsonJavaTypeDescriptor listDescriptor = new JsonJavaTypeDescriptor(new TestParameterizedTypeImpl(String.class, ArrayList.class));
+        JsonJavaTypeDescriptor setDescriptor = new JsonJavaTypeDescriptor(new TestParameterizedTypeImpl(String.class, HashSet.class));
+        List<String> expectedArrayListValue = new ArrayList<>();
+        expectedArrayListValue.add("one");
+        expectedArrayListValue.add("two");
+        Set<String> expectedHashSetValue = new HashSet<>();
+        expectedHashSetValue.add("one");
+        expectedHashSetValue.add("two");
+
+        assertEquals(expectedArrayListValue, listDescriptor.wrap("[\"one\",\"two\"]", wrapperOptions));
+        assertEquals(expectedHashSetValue, setDescriptor.wrap("[\"one\",\"two\"]", wrapperOptions));
     }
 
     private Form createForm(Integer... numbers) {
@@ -118,6 +145,31 @@ public class JsonTypeDescriptorTest {
         @Override
         public int hashCode() {
             return Objects.hash(formFields);
+        }
+    }
+
+    private static class TestParameterizedTypeImpl implements ParameterizedType {
+        private final Class<?> actualType;
+        private final Class<?> rawType;
+
+        public TestParameterizedTypeImpl(Class<?> actualType, Class<?> rawType) {
+            this.actualType = actualType;
+            this.rawType = rawType;
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return new Type[]{actualType};
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return null;
         }
     }
 }

--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJavaTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJavaTypeDescriptor.java
@@ -208,10 +208,9 @@ public class JsonJavaTypeDescriptor extends AbstractClassJavaType<Object> implem
                 ParameterizedType parameterizedType = (ParameterizedType) propertyType;
 
                 for(Class genericType : ReflectionUtils.getGenericTypes(parameterizedType)) {
-                    if(validatedTypes.contains(genericType)) {
+                    if(!validatedTypes.add(genericType)) {
                         continue;
                     }
-                    validatedTypes.add(genericType);
                     Method equalsMethod = ReflectionUtils.getMethodOrNull(genericType, "equals", Object.class);
                     Method hashCodeMethod = ReflectionUtils.getMethodOrNull(genericType, "hashCode");
 
@@ -235,5 +234,5 @@ public class JsonJavaTypeDescriptor extends AbstractClassJavaType<Object> implem
         this.jdbcType = jdbcType;
     }
 
-    private static List<Class> validatedTypes = new ArrayList<>();
+    private static final Set<Class> validatedTypes = Collections.synchronizedSet(new HashSet<>());
 }

--- a/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/type/json/internal/JsonTypeDescriptorTest.java
+++ b/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/type/json/internal/JsonTypeDescriptorTest.java
@@ -2,17 +2,29 @@ package io.hypersistence.utils.hibernate.type.json.internal;
 
 import io.hypersistence.utils.hibernate.type.model.BaseEntity;
 import org.hibernate.HibernateException;
+import org.hibernate.type.descriptor.WrapperOptions;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@RunWith(MockitoJUnitRunner.class)
 public class JsonTypeDescriptorTest {
+    private @Mock WrapperOptions wrapperOptions;
 
     /**
      * If JSON serialization is used,
@@ -51,6 +63,21 @@ public class JsonTypeDescriptorTest {
             fail("Should fail because the propertyType is null!");
         } catch (HibernateException expected) {
         }
+    }
+
+    @Test
+    public void testCollectionPropertyTypes() {
+        JsonJavaTypeDescriptor listDescriptor = new JsonJavaTypeDescriptor(new TestParameterizedTypeImpl(String.class, ArrayList.class));
+        JsonJavaTypeDescriptor setDescriptor = new JsonJavaTypeDescriptor(new TestParameterizedTypeImpl(String.class, HashSet.class));
+        List<String> expectedArrayListValue = new ArrayList<>();
+        expectedArrayListValue.add("one");
+        expectedArrayListValue.add("two");
+        Set<String> expectedHashSetValue = new HashSet<>();
+        expectedHashSetValue.add("one");
+        expectedHashSetValue.add("two");
+
+        assertEquals(expectedArrayListValue, listDescriptor.wrap("[\"one\",\"two\"]", wrapperOptions));
+        assertEquals(expectedHashSetValue, setDescriptor.wrap("[\"one\",\"two\"]", wrapperOptions));
     }
 
     private Form createForm(Integer... numbers) {
@@ -118,6 +145,31 @@ public class JsonTypeDescriptorTest {
         @Override
         public int hashCode() {
             return Objects.hash(formFields);
+        }
+    }
+
+    private static class TestParameterizedTypeImpl implements ParameterizedType {
+        private final Class<?> actualType;
+        private final Class<?> rawType;
+
+        public TestParameterizedTypeImpl(Class<?> actualType, Class<?> rawType) {
+            this.actualType = actualType;
+            this.rawType = rawType;
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return new Type[]{actualType};
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return null;
         }
     }
 }


### PR DESCRIPTION
We use this together with a library that initializes multiple hibernate persistence units concurrently (specifically, [here](https://github.com/tocktix/onami-persist/tree/6b0724c8ae00956a31c013479d2a2ee47efb17c8/src/main/java/org/apache/onami/persist/AllPersistenceUnits.java#L85-L99)) and recently started hitting an intermittent initialization error with a stack trace like this:

```java
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0
	at java.util.ArrayList.add(ArrayList.java:455)
	at java.util.ArrayList.add(ArrayList.java:467)
	at io.hypersistence.utils.hibernate.type.json.internal.JsonTypeDescriptor.validatePropertyType(JsonTypeDescriptor.java:207)
	at io.hypersistence.utils.hibernate.type.json.internal.JsonTypeDescriptor.setPropertyClass(JsonTypeDescriptor.java:195)
	at io.hypersistence.utils.hibernate.type.json.internal.JsonTypeDescriptor.setParameterValues(JsonTypeDescriptor.java:82)
```

I believe the cause of this was a `static ArrayList` used in JsonTypeDescriptor. I'd like to change that to a thread-safe `Set` (there's a `contains` check that also needs to be consolidated to be thread-safe, and a `Set` seemed better suited) to prevent this.

I didn't think it would be valuable to attempt to reproduce the concurrency issue in a unit test, but I did add a test that exercise this code path. Happy to try and improve on that if you have any suggestions.

Thanks!