### PR TITLE
Use Spring Data Range as an alternative to PostgreSQL range type

### DIFF
--- a/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/range/spring/PostgreSQLSpringRangeType.java
+++ b/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/range/spring/PostgreSQLSpringRangeType.java
@@ -1,0 +1,360 @@
+package io.hypersistence.utils.hibernate.type.range.spring;
+
+import io.hypersistence.utils.common.ReflectionUtils;
+import io.hypersistence.utils.hibernate.type.ImmutableType;
+import org.hibernate.HibernateException;
+import org.hibernate.annotations.common.reflection.XProperty;
+import org.hibernate.annotations.common.reflection.java.JavaXMember;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.usertype.DynamicParameterizedType;
+import org.springframework.data.domain.Range;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.util.Properties;
+import java.util.function.Function;
+
+public class PostgreSQLSpringRangeType extends ImmutableType<Range> implements DynamicParameterizedType {
+
+    private static final Range<Integer> EMPTY_INT_RANGE = Range.rightOpen(Integer.MIN_VALUE, Integer.MIN_VALUE);
+    
+    private static final Range<Long> EMPTY_LONG_RANGE = Range.rightOpen(Long.MIN_VALUE, Long.MIN_VALUE);
+    
+    private static final Range<BigDecimal> EMPTY_BIGDECIMAL_RANGE = Range.rightOpen(BigDecimal.ZERO, BigDecimal.ZERO);
+    
+    private static final Range<LocalDateTime> EMPTY_LOCALDATETIME_RANGE = Range.rightOpen(LocalDateTime.MIN, LocalDateTime.MIN);
+    
+    private static final Range<OffsetDateTime> EMPTY_OFFSETDATETIME_RANGE = Range.rightOpen(OffsetDateTime.MIN, OffsetDateTime.MIN);
+    
+    private static final Range<ZonedDateTime> EMPTY_ZONEDDATETIME_RANGE = Range.rightOpen(OffsetDateTime.MIN.toZonedDateTime(), OffsetDateTime.MIN.toZonedDateTime());
+    
+    private static final Range<LocalDate> EMPTY_DATE_RANGE = Range.rightOpen(LocalDate.MIN, LocalDate.MIN);
+
+    private static final DateTimeFormatter LOCAL_DATE_TIME = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH:mm:ss")
+            .optionalStart()
+            .appendPattern(".")
+            .appendFraction(ChronoField.NANO_OF_SECOND, 1, 6, false)
+            .optionalEnd()
+            .toFormatter();
+
+    private static final DateTimeFormatter OFFSET_DATE_TIME = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH:mm:ss")
+            .optionalStart()
+            .appendPattern(".")
+            .appendFraction(ChronoField.NANO_OF_SECOND, 1, 6, false)
+            .optionalEnd()
+            .appendPattern("X")
+            .toFormatter();
+
+    public static final PostgreSQLSpringRangeType INSTANCE = new PostgreSQLSpringRangeType();
+
+    private Type type;
+
+    private Class<?> elementType;
+
+    public PostgreSQLSpringRangeType() {
+        super(Range.class);
+    }
+
+    public PostgreSQLSpringRangeType(Class<?> elementType) {
+        super(Range.class);
+        this.elementType = elementType;
+    }
+    
+    @Override
+    protected Range get(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+        Object pgObject = rs.getObject(position);
+
+        if (pgObject == null) {
+            return null;
+        }
+
+        String type = ReflectionUtils.invokeGetter(pgObject, "type");
+        String value = ReflectionUtils.invokeGetter(pgObject, "value");
+
+        switch (type) {
+            case "int4range":
+                return integerRange(value);
+            case "int8range":
+                return longRange(value);
+            case "numrange":
+                return bigDecimalRange(value);
+            case "tsrange":
+                return localDateTimeRange(value);
+            case "tstzrange":
+                return ZonedDateTime.class.equals(elementType) ? zonedDateTimeRange(value) : offsetDateTimeRange(value);
+            case "daterange":
+                return localDateRange(value);
+            default:
+                throw new HibernateException(
+                        new IllegalStateException("The range type [" + type + "] is not supported!")
+                );
+        }
+    }
+
+    @Override
+    protected void set(PreparedStatement st, Range range, int index, SharedSessionContractImplementor session) throws SQLException {
+        if (range == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
+            ReflectionUtils.invokeSetter(holder, "type", determineRangeType(range));
+            ReflectionUtils.invokeSetter(holder, "value", asString(range));
+            st.setObject(index, holder);
+        }
+    }
+
+    @Override
+    public Range fromStringValue(CharSequence sequence) throws HibernateException {
+        if (sequence != null) {
+            String stringValue = (String) sequence;
+            Class clazz = rangeClass();
+            if (clazz != null) {
+                if (Integer.class.isAssignableFrom(clazz)) {
+                    return integerRange(stringValue);
+                }
+                if (Long.class.isAssignableFrom(clazz)) {
+                    return longRange(stringValue);
+                }
+                if (BigDecimal.class.isAssignableFrom(clazz)) {
+                    return bigDecimalRange(stringValue);
+                }
+                if (LocalDateTime.class.isAssignableFrom(clazz)) {
+                    return localDateTimeRange(stringValue);
+                }
+                if (ZonedDateTime.class.isAssignableFrom(clazz)) {
+                    return zonedDateTimeRange(stringValue);
+                }
+                if (LocalDate.class.isAssignableFrom(clazz)) {
+                    return localDateRange(stringValue);
+                }
+                throw new HibernateException(
+                        new IllegalStateException("The range type [" + type + "] is not supported!")
+                );
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void setParameterValues(Properties properties) {
+        final XProperty xProperty = (XProperty) properties.get(DynamicParameterizedType.XPROPERTY);
+        if (xProperty instanceof JavaXMember) {
+            type = ((JavaXMember) xProperty).getJavaType();
+        } else {
+            type = ((ParameterType) properties.get(PARAMETER_TYPE)).getReturnedClass();
+        }
+
+        if (type instanceof ParameterizedType) {
+            elementType = (Class<?>) ((ParameterizedType) type).getActualTypeArguments()[0];
+        }
+    }
+
+    @Override
+    public int getSqlType() {
+        return Types.OTHER;
+    }
+
+    private String determineRangeType(Range<?> range) {
+        Type clazz = this.elementType;
+
+        if (clazz.equals(Integer.class)) {
+            return "int4range";
+        } else if (clazz.equals(Long.class)) {
+            return "int8range";
+        } else if (clazz.equals(BigDecimal.class)) {
+            return "numrange";
+        } else if (clazz.equals(LocalDateTime.class)) {
+            return "tsrange";
+        } else if (clazz.equals(ZonedDateTime.class) || clazz.equals(OffsetDateTime.class)) {
+            return "tstzrange";
+        } else if (clazz.equals(LocalDate.class)) {
+            return "daterange";
+        }
+
+        throw new HibernateException(
+                new IllegalStateException("The class [" + clazz + "] is not supported!")
+        );
+    }
+
+    public static <T extends Comparable<?>> Range<T> ofString(String str, Function<String, T> converter, Class<T> clazz) {
+        if ("empty".equals(str)) {
+            if (clazz.equals(Integer.class)) {
+                return (Range<T>) EMPTY_INT_RANGE;
+            } else if (clazz.equals(Long.class)) {
+                return (Range<T>) EMPTY_LONG_RANGE;
+            } else if (clazz.equals(BigDecimal.class)) {
+                return (Range<T>) EMPTY_BIGDECIMAL_RANGE;
+            } else if (clazz.equals(LocalDateTime.class)) {
+                return (Range<T>) EMPTY_LOCALDATETIME_RANGE;
+            } else if (clazz.equals(ZonedDateTime.class)) {
+                return (Range<T>) EMPTY_ZONEDDATETIME_RANGE;
+            } else if (clazz.equals(OffsetDateTime.class)) {
+                return (Range<T>) EMPTY_OFFSETDATETIME_RANGE;
+            } else if (clazz.equals(LocalDate.class)) {
+                return (Range<T>) EMPTY_DATE_RANGE;
+            }
+        }
+
+        int delim = str.indexOf(',');
+
+        if (delim == -1) {
+            throw new HibernateException(
+                    new IllegalArgumentException("Cannot find comma character")
+            );
+        }
+
+        String lowerStr = str.substring(1, delim);
+        String upperStr = str.substring(delim + 1, str.length() - 1);
+
+        Range.Bound<T> lowerBound =  Range.Bound.unbounded();
+        Range.Bound<T> upperBound = Range.Bound.unbounded();
+
+        if (!lowerStr.isEmpty()) {
+            T lower = converter.apply(lowerStr);
+            lowerBound = str.charAt(0) == '[' ? Range.Bound.inclusive(lower) : Range.Bound.exclusive(lower);
+        }
+
+        if (!upperStr.isEmpty()) {
+            T upper = converter.apply(upperStr);
+            upperBound = str.charAt(str.length() - 1) == ']' ? Range.Bound.inclusive(upper) : Range.Bound.exclusive(upper);
+        }
+
+        return Range.of(lowerBound, upperBound);
+
+    }
+
+    public static Range<BigDecimal> bigDecimalRange(String range) {
+        return ofString(range, BigDecimal::new, BigDecimal.class);
+    }
+
+    public static Range<Integer> integerRange(String range) {
+        return ofString(range, Integer::parseInt, Integer.class);
+    }
+
+    public static Range<Long> longRange(String range) {
+        return ofString(range, Long::parseLong, Long.class);
+    }
+
+    public static Range<LocalDateTime> localDateTimeRange(String range) {
+        return ofString(range, parseLocalDateTime().compose(unquote()), LocalDateTime.class);
+    }
+
+    public static Range<LocalDate> localDateRange(String range) {
+        Function<String, LocalDate> parseLocalDate = LocalDate::parse;
+        return ofString(range, parseLocalDate.compose(unquote()), LocalDate.class);
+    }
+
+    public static Range<ZonedDateTime> zonedDateTimeRange(String rangeStr) {
+        Range<ZonedDateTime> range = ofString(rangeStr, parseZonedDateTime().compose(unquote()), ZonedDateTime.class);
+        if (range.getLowerBound().isBounded() && range.getUpperBound().isBounded()) {
+            ZoneId lowerZone = range.getLowerBound().getValue().get().getZone();
+            ZoneId upperZone = range.getUpperBound().getValue().get().getZone();
+            if (!lowerZone.equals(upperZone)) {
+                Duration lowerDst = ZoneId.systemDefault().getRules().getDaylightSavings(range.getLowerBound().getValue().get().toInstant());
+                Duration upperDst = ZoneId.systemDefault().getRules().getDaylightSavings(range.getUpperBound().getValue().get().toInstant());
+                long dstSeconds = upperDst.minus(lowerDst).getSeconds();
+                if (dstSeconds < 0) {
+                    dstSeconds *= -1;
+                }
+                long zoneDriftSeconds = ((ZoneOffset) lowerZone).getTotalSeconds() - ((ZoneOffset) upperZone).getTotalSeconds();
+                if (zoneDriftSeconds < 0) {
+                    zoneDriftSeconds *= -1;
+                }
+
+                if (dstSeconds != zoneDriftSeconds) {
+                    throw new HibernateException(
+                            new IllegalArgumentException("The upper and lower bounds must be in same time zone!")
+                    );
+                }
+            }
+        }
+        return range;
+    }
+
+    public static Range<OffsetDateTime> offsetDateTimeRange(String rangeStr) {
+        return ofString(rangeStr, parseOffsetDateTime().compose(unquote()), OffsetDateTime.class);
+    }
+
+    private static Function<String, LocalDateTime> parseLocalDateTime() {
+        return str -> {
+            try {
+                return LocalDateTime.parse(str, LOCAL_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                return LocalDateTime.parse(str);
+            }
+        };
+    }
+
+    private static Function<String, ZonedDateTime> parseZonedDateTime() {
+        return s -> {
+            try {
+                return ZonedDateTime.parse(s, OFFSET_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                return ZonedDateTime.parse(s);
+            }
+        };
+    }
+
+    private static Function<String, OffsetDateTime> parseOffsetDateTime() {
+        return s -> {
+            try {
+                return OffsetDateTime.parse(s, OFFSET_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                return OffsetDateTime.parse(s);
+            }
+        };
+    }
+
+    private static Function<String, String> unquote() {
+        return s -> {
+            if (s.charAt(0) == '\"' && s.charAt(s.length() - 1) == '\"') {
+                return s.substring(1, s.length() - 1);
+            }
+
+            return s;
+        };
+    }
+
+    String asString(Range<?> range) {
+
+        if (!range.getLowerBound().isBounded() && !range.getUpperBound().isBounded()) {
+            return "(,)";
+        }
+        if (range.getLowerBound().getValue().equals(range.getUpperBound().getValue())) {
+            return "empty";
+        }
+
+        Range.Bound<?> lower = range.getLowerBound();
+        Range.Bound<?> upper = range.getUpperBound();
+
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(lower.isBounded() ? lower.isInclusive() ? "[" : "(" : "(");
+        lower.getValue().ifPresent(sb::append);
+        sb.append(",");
+        upper.getValue().ifPresent(sb::append);
+        sb.append(upper.isBounded() ? upper.isInclusive() ? "]": ")": ")");
+
+        return sb.toString();
+    }
+
+    private Class rangeClass() {
+            if (type instanceof ParameterizedType) {
+                Type[] types = ((ParameterizedType) type).getActualTypeArguments();
+                return (Class) types[0];
+            }
+            return null;
+        }
+}

--- a/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/hibernate/type/range/spring/PostgreSQLSpringRangeTypeTest.java
+++ b/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/hibernate/type/range/spring/PostgreSQLSpringRangeTypeTest.java
@@ -1,0 +1,348 @@
+package io.hypersistence.utils.hibernate.type.range.spring;
+
+import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+import org.springframework.data.domain.Range;
+
+import java.math.BigDecimal;
+import java.time.*;
+
+import static io.hypersistence.utils.hibernate.type.range.spring.PostgreSQLSpringRangeType.integerRange;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class PostgreSQLSpringRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    private static final ZoneOffset DEFAULT_OFFSET = OffsetDateTime.now().getOffset();
+
+    private final Range<BigDecimal> numeric = Range.rightOpen(new BigDecimal("0.5"), new BigDecimal("0.89"));
+
+    private final Range<BigDecimal> numericEmpty = Range.rightOpen(BigDecimal.ZERO, BigDecimal.ZERO);
+
+    private final Range<Long> int8Range = Range.rightOpen(0L, 18L);
+
+    private final Range<Long> int8RangeEmpty = Range.rightOpen(Long.MIN_VALUE, Long.MIN_VALUE);
+
+    private final Range<Integer> int4Range = Range.rightOpen(0, 18);
+
+    private final Range<Integer> int4RangeEmpty = Range.rightOpen(Integer.MIN_VALUE, Integer.MIN_VALUE);
+
+    private final Range<LocalDateTime> localDateTimeRange = Range.rightOpen(
+            LocalDateTime.of(2014, Month.APRIL, 28, 16, 0, 49),
+            LocalDateTime.of(2015, Month.APRIL, 28, 16, 0, 49));
+
+    private final Range<LocalDateTime> localDateTimeRangeEmpty = Range.rightOpen(LocalDateTime.MIN, LocalDateTime.MIN);
+
+    private final Range<ZonedDateTime> tsTz = Range.rightOpen(
+            OffsetDateTime.of(LocalDateTime.of(2007, Month.DECEMBER, 3, 10, 15, 30), ZoneOffset.ofHours(1)).toZonedDateTime(),
+            OffsetDateTime.of(LocalDateTime.of(2008, Month.DECEMBER, 3, 10, 15, 30), ZoneOffset.ofHours(1)).toZonedDateTime());
+
+    private final Range<ZonedDateTime> tsTzEmpty = Range.rightOpen(OffsetDateTime.MIN.toZonedDateTime(), OffsetDateTime.MIN.toZonedDateTime());
+
+    private final Range<OffsetDateTime> tsTzO = Range.rightOpen(
+            OffsetDateTime.of(LocalDateTime.of(2007, Month.MAY, 3, 10, 15, 30), DEFAULT_OFFSET),
+            OffsetDateTime.of(LocalDateTime.of(2008, Month.MAY, 3, 10, 15, 30), DEFAULT_OFFSET)
+    );
+
+//    private final Range<OffsetDateTime> tsTz0Empty = Range.rightOpen(OffsetDateTime.MIN.toZonedDateTime().)
+
+    private final Range<LocalDate> dateRange = Range.rightOpen(LocalDate.of(1992, Month.JANUARY, 13), LocalDate.of(1995, Month.JANUARY, 13));
+
+    private final Range<LocalDate> dateRangeEmpty = Range.rightOpen(LocalDate.MIN, LocalDate.MIN);
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class[]{
+                Restriction.class
+        };
+    }
+
+    @Test
+    public void test() {
+        Restriction ageRestrictionInt = doInJPA(entityManager -> {
+            entityManager.persist(new Restriction());
+
+            Restriction restriction = new Restriction();
+            restriction.setRangeInt(int4Range);
+            restriction.setRangeIntEmpty(int4RangeEmpty);
+            restriction.setRangeLong(int8Range);
+            restriction.setRangeLongEmpty(int8RangeEmpty);
+            restriction.setRangeBigDecimal(numeric);
+            restriction.setRangeBigDecimalEmpty(numericEmpty);
+            restriction.setRangeLocalDateTime(localDateTimeRange);
+            restriction.setRangeLocalDateTimeEmpty(localDateTimeRangeEmpty);
+            restriction.setRangeZonedDateTime(tsTz);
+            restriction.setRangeZonedDateTimeEmpty(tsTzEmpty);
+            restriction.setRangeLocalDate(dateRange);
+            restriction.setRangeLocalDateEmpty(dateRangeEmpty);
+            restriction.setOffsetZonedDateTime(tsTzO);
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+            assertEquals(int4Range, ar.getRangeInt());
+            assertEquals(int4RangeEmpty, ar.getRangeIntEmpty());
+            assertEquals(int8Range, ar.getRangeLong());
+            assertEquals(int8RangeEmpty, ar.getRangeLongEmpty());
+            assertEquals(numeric, ar.getRangeBigDecimal());
+            assertEquals(numericEmpty, ar.getRangeBigDecimalEmpty());
+            assertEquals(localDateTimeRange, ar.getRangeLocalDateTime());
+            assertEquals(localDateTimeRangeEmpty, ar.getRangeLocalDateTimeEmpty());
+            assertEquals(tsTzO, ar.getOffsetZonedDateTime());
+            assertEquals(dateRange, ar.getRangeLocalDate());
+            assertEquals(dateRangeEmpty, ar.getRangeLocalDateEmpty());
+
+            ZoneId zone = ar.getRangeZonedDateTime().getLowerBound().getValue().get().getZone();
+            ZonedDateTime lower = tsTz.getLowerBound().getValue().get().withZoneSameInstant(zone);
+            ZonedDateTime upper = tsTz.getUpperBound().getValue().get().withZoneSameInstant(zone);
+            assertEquals(ar.getRangeZonedDateTime(), Range.rightOpen(lower, upper));
+
+            ZoneId zoneEmpty = ar.getRangeZonedDateTimeEmpty().getLowerBound().getValue().get().getZone();
+            ZonedDateTime lowerEmpty = tsTzEmpty.getLowerBound().getValue().get().withZoneSameInstant(zoneEmpty);
+            ZonedDateTime upperEmpty = tsTzEmpty.getUpperBound().getValue().get().withZoneSameInstant(zoneEmpty);
+            assertEquals(ar.getRangeZonedDateTimeEmpty(), Range.rightOpen(lowerEmpty, upperEmpty));
+
+        });
+    }
+
+    @Test
+    public void testNullRange() {
+        Restriction ageRestrictionInt = doInJPA(entityManager -> {
+            Restriction restriction = new Restriction();
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+            assertNull(ar.getRangeInt());
+            assertNull(ar.getRangeIntEmpty());
+            assertNull(ar.getRangeLong());
+            assertNull(ar.getRangeLongEmpty());
+            assertNull(ar.getRangeBigDecimal());
+            assertNull(ar.getRangeBigDecimalEmpty());
+            assertNull(ar.getRangeLocalDateTime());
+            assertNull(ar.getRangeLocalDateTimeEmpty());
+            assertNull(ar.getRangeLocalDate());
+            assertNull(ar.getRangeLocalDateEmpty());
+            assertNull(ar.getRangeZonedDateTime());
+            assertNull(ar.getRangeZonedDateTimeEmpty());
+        });
+    }
+
+    @Test
+    public void testUnboundedRangeIsRejected() {
+        Restriction ageRestrictionInt = doInJPA(entityManager -> {
+            Restriction restriction = new Restriction();
+            restriction.setRangeInt(Range.unbounded());
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+            assertEquals(ar.getRangeInt(), Range.unbounded());
+        });
+    }
+
+    @Test
+    public void testUnboundedRangeStringIsRejected() {
+        PostgreSQLSpringRangeType instance = PostgreSQLSpringRangeType.INSTANCE;
+        assertEquals(Range.unbounded(), integerRange("(,)"));
+    }
+
+    @Test
+    public void testSingleBoundedRanges() {
+        PostgreSQLSpringRangeType instance = PostgreSQLSpringRangeType.INSTANCE;
+
+        assertEquals("(,)", instance.asString(Range.unbounded()));
+        assertEquals("(1,)", instance.asString(Range.rightUnbounded(Range.Bound.exclusive(1))));
+        assertEquals("[2,)", instance.asString(Range.rightUnbounded(Range.Bound.inclusive(2))));
+        assertEquals("(,3)", instance.asString(Range.leftUnbounded(Range.Bound.exclusive(3))));
+        assertEquals("(,4]", instance.asString(Range.leftUnbounded(Range.Bound.inclusive(4))));
+
+        assertEquals(Range.rightUnbounded(Range.Bound.exclusive(5)), integerRange("(5,)"));
+        assertEquals(Range.rightUnbounded(Range.Bound.inclusive(6)), integerRange("[6,)"));
+        assertEquals(Range.leftUnbounded(Range.Bound.exclusive(7)), integerRange("(,7)"));
+        assertEquals(Range.leftUnbounded(Range.Bound.inclusive(8)), integerRange("(,8]"));
+    }
+
+    @Entity(name = "AgeRestriction")
+    @Table(name = "age_restriction")
+    public static class Restriction {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_int", columnDefinition = "int4Range")
+        private Range<Integer> rangeInt;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_int_empty", columnDefinition = "int4Range")
+        private Range<Integer> rangeIntEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_long", columnDefinition = "int8range")
+        private Range<Long> rangeLong;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_long_empty", columnDefinition = "int8range")
+        private Range<Long> rangeLongEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_numeric", columnDefinition = "numrange")
+        private Range<BigDecimal> rangeBigDecimal;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_numeric_empty", columnDefinition = "numrange")
+        private Range<BigDecimal> rangeBigDecimalEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_tsrange", columnDefinition = "tsrange")
+        private Range<LocalDateTime> rangeLocalDateTime;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_tsrange_empty", columnDefinition = "tsrange")
+        private Range<LocalDateTime> rangeLocalDateTimeEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_tstzrange", columnDefinition = "tstzrange")
+        private Range<ZonedDateTime> rangeZonedDateTime;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_tstzrange_empty", columnDefinition = "tstzrange")
+        private Range<ZonedDateTime> rangeZonedDateTimeEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_otstzrange", columnDefinition = "tstzrange")
+        private Range<OffsetDateTime> offsetZonedDateTime;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_daterange", columnDefinition = "daterange")
+        private Range<LocalDate> rangeLocalDate;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_daterange_empty", columnDefinition = "daterange")
+        private Range<LocalDate> rangeLocalDateEmpty;
+
+        public Long getId() {
+            return id;
+        }
+
+        public Range<Long> getRangeLong() {
+            return rangeLong;
+        }
+
+        public void setRangeLong(Range<Long> rangeLong) {
+            this.rangeLong = rangeLong;
+        }
+
+        public Range<Long> getRangeLongEmpty() {
+            return rangeLongEmpty;
+        }
+
+        public void setRangeLongEmpty(Range<Long> rangeLongEmpty) {
+            this.rangeLongEmpty = rangeLongEmpty;
+        }
+
+        public Range<Integer> getRangeInt() {
+            return rangeInt;
+        }
+
+        public void setRangeInt(Range<Integer> rangeInt) {
+            this.rangeInt = rangeInt;
+        }
+
+        public Range<Integer> getRangeIntEmpty() {
+            return rangeIntEmpty;
+        }
+
+        public void setRangeIntEmpty(Range<Integer> rangeIntEmpty) {
+            this.rangeIntEmpty = rangeIntEmpty;
+        }
+        
+        public Range<BigDecimal> getRangeBigDecimal() {
+            return rangeBigDecimal;
+        }
+
+        public void setRangeBigDecimal(Range<BigDecimal> rangeBigDecimal) {
+            this.rangeBigDecimal = rangeBigDecimal;
+        }
+
+        public void setRangeLocalDateTime(Range<LocalDateTime> rangeLocalDateTime) {
+            this.rangeLocalDateTime = rangeLocalDateTime;
+        }
+
+        public Range<ZonedDateTime> getRangeZonedDateTime() {
+            return rangeZonedDateTime;
+        }
+
+        public void setRangeZonedDateTime(Range<ZonedDateTime> rangeZonedDateTime) {
+            this.rangeZonedDateTime = rangeZonedDateTime;
+        }
+
+        public Range<LocalDate> getRangeLocalDate() {
+            return rangeLocalDate;
+        }
+
+        public void setRangeLocalDate(Range<LocalDate> localDateRange) {
+            this.rangeLocalDate = localDateRange;
+        }
+
+        public Range<OffsetDateTime> getOffsetZonedDateTime() {
+            return offsetZonedDateTime;
+        }
+
+        public void setOffsetZonedDateTime(Range<OffsetDateTime> offsetZonedDateTime) {
+            this.offsetZonedDateTime = offsetZonedDateTime;
+        }
+
+        public Range<BigDecimal> getRangeBigDecimalEmpty() {
+            return rangeBigDecimalEmpty;
+        }
+
+        public void setRangeBigDecimalEmpty(Range<BigDecimal> rangeBigDecimalEmpty) {
+            this.rangeBigDecimalEmpty = rangeBigDecimalEmpty;
+        }
+
+        public Range<LocalDateTime> getRangeLocalDateTime() {
+            return rangeLocalDateTime;
+        }
+
+        public Range<LocalDateTime> getRangeLocalDateTimeEmpty() {
+            return rangeLocalDateTimeEmpty;
+        }
+
+        public void setRangeLocalDateTimeEmpty(Range<LocalDateTime> rangeLocalDateTimeEmpty) {
+            this.rangeLocalDateTimeEmpty = rangeLocalDateTimeEmpty;
+        }
+
+        public Range<ZonedDateTime> getRangeZonedDateTimeEmpty() {
+            return rangeZonedDateTimeEmpty;
+        }
+
+        public void setRangeZonedDateTimeEmpty(Range<ZonedDateTime> rangeZonedDateTimeEmpty) {
+            this.rangeZonedDateTimeEmpty = rangeZonedDateTimeEmpty;
+        }
+
+        public Range<LocalDate> getRangeLocalDateEmpty() {
+            return rangeLocalDateEmpty;
+        }
+
+        public void setRangeLocalDateEmpty(Range<LocalDate> localDateRangeEmpty) {
+            this.rangeLocalDateEmpty = localDateRangeEmpty;
+        }
+    }
+}

--- a/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/range/spring/PostgreSQLSpringRangeType.java
+++ b/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/range/spring/PostgreSQLSpringRangeType.java
@@ -1,0 +1,360 @@
+package io.hypersistence.utils.hibernate.type.range.spring;
+
+import io.hypersistence.utils.common.ReflectionUtils;
+import io.hypersistence.utils.hibernate.type.ImmutableType;
+import org.hibernate.HibernateException;
+import org.hibernate.annotations.common.reflection.XProperty;
+import org.hibernate.annotations.common.reflection.java.JavaXMember;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.usertype.DynamicParameterizedType;
+import org.springframework.data.domain.Range;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.util.Properties;
+import java.util.function.Function;
+
+public class PostgreSQLSpringRangeType extends ImmutableType<Range> implements DynamicParameterizedType {
+
+    private static final Range<Integer> EMPTY_INT_RANGE = Range.rightOpen(Integer.MIN_VALUE, Integer.MIN_VALUE);
+    
+    private static final Range<Long> EMPTY_LONG_RANGE = Range.rightOpen(Long.MIN_VALUE, Long.MIN_VALUE);
+    
+    private static final Range<BigDecimal> EMPTY_BIGDECIMAL_RANGE = Range.rightOpen(BigDecimal.ZERO, BigDecimal.ZERO);
+    
+    private static final Range<LocalDateTime> EMPTY_LOCALDATETIME_RANGE = Range.rightOpen(LocalDateTime.MIN, LocalDateTime.MIN);
+    
+    private static final Range<OffsetDateTime> EMPTY_OFFSETDATETIME_RANGE = Range.rightOpen(OffsetDateTime.MIN, OffsetDateTime.MIN);
+    
+    private static final Range<ZonedDateTime> EMPTY_ZONEDDATETIME_RANGE = Range.rightOpen(OffsetDateTime.MIN.toZonedDateTime(), OffsetDateTime.MIN.toZonedDateTime());
+    
+    private static final Range<LocalDate> EMPTY_DATE_RANGE = Range.rightOpen(LocalDate.MIN, LocalDate.MIN);
+
+    private static final DateTimeFormatter LOCAL_DATE_TIME = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH:mm:ss")
+            .optionalStart()
+            .appendPattern(".")
+            .appendFraction(ChronoField.NANO_OF_SECOND, 1, 6, false)
+            .optionalEnd()
+            .toFormatter();
+
+    private static final DateTimeFormatter OFFSET_DATE_TIME = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH:mm:ss")
+            .optionalStart()
+            .appendPattern(".")
+            .appendFraction(ChronoField.NANO_OF_SECOND, 1, 6, false)
+            .optionalEnd()
+            .appendPattern("X")
+            .toFormatter();
+
+    public static final PostgreSQLSpringRangeType INSTANCE = new PostgreSQLSpringRangeType();
+
+    private Type type;
+
+    private Class<?> elementType;
+
+    public PostgreSQLSpringRangeType() {
+        super(Range.class);
+    }
+
+    public PostgreSQLSpringRangeType(Class<?> elementType) {
+        super(Range.class);
+        this.elementType = elementType;
+    }
+    
+    @Override
+    protected Range get(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+        Object pgObject = rs.getObject(position);
+
+        if (pgObject == null) {
+            return null;
+        }
+
+        String type = ReflectionUtils.invokeGetter(pgObject, "type");
+        String value = ReflectionUtils.invokeGetter(pgObject, "value");
+
+        switch (type) {
+            case "int4range":
+                return integerRange(value);
+            case "int8range":
+                return longRange(value);
+            case "numrange":
+                return bigDecimalRange(value);
+            case "tsrange":
+                return localDateTimeRange(value);
+            case "tstzrange":
+                return ZonedDateTime.class.equals(elementType) ? zonedDateTimeRange(value) : offsetDateTimeRange(value);
+            case "daterange":
+                return localDateRange(value);
+            default:
+                throw new HibernateException(
+                        new IllegalStateException("The range type [" + type + "] is not supported!")
+                );
+        }
+    }
+
+    @Override
+    protected void set(PreparedStatement st, Range range, int index, SharedSessionContractImplementor session) throws SQLException {
+        if (range == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
+            ReflectionUtils.invokeSetter(holder, "type", determineRangeType(range));
+            ReflectionUtils.invokeSetter(holder, "value", asString(range));
+            st.setObject(index, holder);
+        }
+    }
+
+    @Override
+    public Range fromStringValue(CharSequence sequence) throws HibernateException {
+        if (sequence != null) {
+            String stringValue = (String) sequence;
+            Class clazz = rangeClass();
+            if (clazz != null) {
+                if (Integer.class.isAssignableFrom(clazz)) {
+                    return integerRange(stringValue);
+                }
+                if (Long.class.isAssignableFrom(clazz)) {
+                    return longRange(stringValue);
+                }
+                if (BigDecimal.class.isAssignableFrom(clazz)) {
+                    return bigDecimalRange(stringValue);
+                }
+                if (LocalDateTime.class.isAssignableFrom(clazz)) {
+                    return localDateTimeRange(stringValue);
+                }
+                if (ZonedDateTime.class.isAssignableFrom(clazz)) {
+                    return zonedDateTimeRange(stringValue);
+                }
+                if (LocalDate.class.isAssignableFrom(clazz)) {
+                    return localDateRange(stringValue);
+                }
+                throw new HibernateException(
+                        new IllegalStateException("The range type [" + type + "] is not supported!")
+                );
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void setParameterValues(Properties properties) {
+        final XProperty xProperty = (XProperty) properties.get(DynamicParameterizedType.XPROPERTY);
+        if (xProperty instanceof JavaXMember) {
+            type = ((JavaXMember) xProperty).getJavaType();
+        } else {
+            type = ((ParameterType) properties.get(PARAMETER_TYPE)).getReturnedClass();
+        }
+
+        if (type instanceof ParameterizedType) {
+            elementType = (Class<?>) ((ParameterizedType) type).getActualTypeArguments()[0];
+        }
+    }
+
+    @Override
+    public int getSqlType() {
+        return Types.OTHER;
+    }
+
+    private String determineRangeType(Range<?> range) {
+        Type clazz = this.elementType;
+
+        if (clazz.equals(Integer.class)) {
+            return "int4range";
+        } else if (clazz.equals(Long.class)) {
+            return "int8range";
+        } else if (clazz.equals(BigDecimal.class)) {
+            return "numrange";
+        } else if (clazz.equals(LocalDateTime.class)) {
+            return "tsrange";
+        } else if (clazz.equals(ZonedDateTime.class) || clazz.equals(OffsetDateTime.class)) {
+            return "tstzrange";
+        } else if (clazz.equals(LocalDate.class)) {
+            return "daterange";
+        }
+
+        throw new HibernateException(
+                new IllegalStateException("The class [" + clazz + "] is not supported!")
+        );
+    }
+
+    public static <T extends Comparable<?>> Range<T> ofString(String str, Function<String, T> converter, Class<T> clazz) {
+        if ("empty".equals(str)) {
+            if (clazz.equals(Integer.class)) {
+                return (Range<T>) EMPTY_INT_RANGE;
+            } else if (clazz.equals(Long.class)) {
+                return (Range<T>) EMPTY_LONG_RANGE;
+            } else if (clazz.equals(BigDecimal.class)) {
+                return (Range<T>) EMPTY_BIGDECIMAL_RANGE;
+            } else if (clazz.equals(LocalDateTime.class)) {
+                return (Range<T>) EMPTY_LOCALDATETIME_RANGE;
+            } else if (clazz.equals(ZonedDateTime.class)) {
+                return (Range<T>) EMPTY_ZONEDDATETIME_RANGE;
+            } else if (clazz.equals(OffsetDateTime.class)) {
+                return (Range<T>) EMPTY_OFFSETDATETIME_RANGE;
+            } else if (clazz.equals(LocalDate.class)) {
+                return (Range<T>) EMPTY_DATE_RANGE;
+            }
+        }
+
+        int delim = str.indexOf(',');
+
+        if (delim == -1) {
+            throw new HibernateException(
+                    new IllegalArgumentException("Cannot find comma character")
+            );
+        }
+
+        String lowerStr = str.substring(1, delim);
+        String upperStr = str.substring(delim + 1, str.length() - 1);
+
+        Range.Bound<T> lowerBound =  Range.Bound.unbounded();
+        Range.Bound<T> upperBound = Range.Bound.unbounded();
+
+        if (!lowerStr.isEmpty()) {
+            T lower = converter.apply(lowerStr);
+            lowerBound = str.charAt(0) == '[' ? Range.Bound.inclusive(lower) : Range.Bound.exclusive(lower);
+        }
+
+        if (!upperStr.isEmpty()) {
+            T upper = converter.apply(upperStr);
+            upperBound = str.charAt(str.length() - 1) == ']' ? Range.Bound.inclusive(upper) : Range.Bound.exclusive(upper);
+        }
+
+        return Range.of(lowerBound, upperBound);
+
+    }
+
+    public static Range<BigDecimal> bigDecimalRange(String range) {
+        return ofString(range, BigDecimal::new, BigDecimal.class);
+    }
+
+    public static Range<Integer> integerRange(String range) {
+        return ofString(range, Integer::parseInt, Integer.class);
+    }
+
+    public static Range<Long> longRange(String range) {
+        return ofString(range, Long::parseLong, Long.class);
+    }
+
+    public static Range<LocalDateTime> localDateTimeRange(String range) {
+        return ofString(range, parseLocalDateTime().compose(unquote()), LocalDateTime.class);
+    }
+
+    public static Range<LocalDate> localDateRange(String range) {
+        Function<String, LocalDate> parseLocalDate = LocalDate::parse;
+        return ofString(range, parseLocalDate.compose(unquote()), LocalDate.class);
+    }
+
+    public static Range<ZonedDateTime> zonedDateTimeRange(String rangeStr) {
+        Range<ZonedDateTime> range = ofString(rangeStr, parseZonedDateTime().compose(unquote()), ZonedDateTime.class);
+        if (range.getLowerBound().isBounded() && range.getUpperBound().isBounded()) {
+            ZoneId lowerZone = range.getLowerBound().getValue().get().getZone();
+            ZoneId upperZone = range.getUpperBound().getValue().get().getZone();
+            if (!lowerZone.equals(upperZone)) {
+                Duration lowerDst = ZoneId.systemDefault().getRules().getDaylightSavings(range.getLowerBound().getValue().get().toInstant());
+                Duration upperDst = ZoneId.systemDefault().getRules().getDaylightSavings(range.getUpperBound().getValue().get().toInstant());
+                long dstSeconds = upperDst.minus(lowerDst).getSeconds();
+                if (dstSeconds < 0) {
+                    dstSeconds *= -1;
+                }
+                long zoneDriftSeconds = ((ZoneOffset) lowerZone).getTotalSeconds() - ((ZoneOffset) upperZone).getTotalSeconds();
+                if (zoneDriftSeconds < 0) {
+                    zoneDriftSeconds *= -1;
+                }
+
+                if (dstSeconds != zoneDriftSeconds) {
+                    throw new HibernateException(
+                            new IllegalArgumentException("The upper and lower bounds must be in same time zone!")
+                    );
+                }
+            }
+        }
+        return range;
+    }
+
+    public static Range<OffsetDateTime> offsetDateTimeRange(String rangeStr) {
+        return ofString(rangeStr, parseOffsetDateTime().compose(unquote()), OffsetDateTime.class);
+    }
+
+    private static Function<String, LocalDateTime> parseLocalDateTime() {
+        return str -> {
+            try {
+                return LocalDateTime.parse(str, LOCAL_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                return LocalDateTime.parse(str);
+            }
+        };
+    }
+
+    private static Function<String, ZonedDateTime> parseZonedDateTime() {
+        return s -> {
+            try {
+                return ZonedDateTime.parse(s, OFFSET_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                return ZonedDateTime.parse(s);
+            }
+        };
+    }
+
+    private static Function<String, OffsetDateTime> parseOffsetDateTime() {
+        return s -> {
+            try {
+                return OffsetDateTime.parse(s, OFFSET_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                return OffsetDateTime.parse(s);
+            }
+        };
+    }
+
+    private static Function<String, String> unquote() {
+        return s -> {
+            if (s.charAt(0) == '\"' && s.charAt(s.length() - 1) == '\"') {
+                return s.substring(1, s.length() - 1);
+            }
+
+            return s;
+        };
+    }
+
+    String asString(Range<?> range) {
+
+        if (!range.getLowerBound().isBounded() && !range.getUpperBound().isBounded()) {
+            return "(,)";
+        }
+        if (range.getLowerBound().getValue().equals(range.getUpperBound().getValue())) {
+            return "empty";
+        }
+
+        Range.Bound<?> lower = range.getLowerBound();
+        Range.Bound<?> upper = range.getUpperBound();
+
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(lower.isBounded() ? lower.isInclusive() ? "[" : "(" : "(");
+        lower.getValue().ifPresent(sb::append);
+        sb.append(",");
+        upper.getValue().ifPresent(sb::append);
+        sb.append(upper.isBounded() ? upper.isInclusive() ? "]": ")": ")");
+
+        return sb.toString();
+    }
+
+    private Class rangeClass() {
+            if (type instanceof ParameterizedType) {
+                Type[] types = ((ParameterizedType) type).getActualTypeArguments();
+                return (Class) types[0];
+            }
+            return null;
+        }
+}

--- a/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/type/range/spring/PostgreSQLSpringRangeTypeTest.java
+++ b/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/type/range/spring/PostgreSQLSpringRangeTypeTest.java
@@ -1,0 +1,348 @@
+package io.hypersistence.utils.hibernate.type.range.spring;
+
+import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+import org.springframework.data.domain.Range;
+
+import java.math.BigDecimal;
+import java.time.*;
+
+import static io.hypersistence.utils.hibernate.type.range.spring.PostgreSQLSpringRangeType.integerRange;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class PostgreSQLSpringRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    private static final ZoneOffset DEFAULT_OFFSET = OffsetDateTime.now().getOffset();
+
+    private final Range<BigDecimal> numeric = Range.rightOpen(new BigDecimal("0.5"), new BigDecimal("0.89"));
+
+    private final Range<BigDecimal> numericEmpty = Range.rightOpen(BigDecimal.ZERO, BigDecimal.ZERO);
+
+    private final Range<Long> int8Range = Range.rightOpen(0L, 18L);
+
+    private final Range<Long> int8RangeEmpty = Range.rightOpen(Long.MIN_VALUE, Long.MIN_VALUE);
+
+    private final Range<Integer> int4Range = Range.rightOpen(0, 18);
+
+    private final Range<Integer> int4RangeEmpty = Range.rightOpen(Integer.MIN_VALUE, Integer.MIN_VALUE);
+
+    private final Range<LocalDateTime> localDateTimeRange = Range.rightOpen(
+            LocalDateTime.of(2014, Month.APRIL, 28, 16, 0, 49),
+            LocalDateTime.of(2015, Month.APRIL, 28, 16, 0, 49));
+
+    private final Range<LocalDateTime> localDateTimeRangeEmpty = Range.rightOpen(LocalDateTime.MIN, LocalDateTime.MIN);
+
+    private final Range<ZonedDateTime> tsTz = Range.rightOpen(
+            OffsetDateTime.of(LocalDateTime.of(2007, Month.DECEMBER, 3, 10, 15, 30), ZoneOffset.ofHours(1)).toZonedDateTime(),
+            OffsetDateTime.of(LocalDateTime.of(2008, Month.DECEMBER, 3, 10, 15, 30), ZoneOffset.ofHours(1)).toZonedDateTime());
+
+    private final Range<ZonedDateTime> tsTzEmpty = Range.rightOpen(OffsetDateTime.MIN.toZonedDateTime(), OffsetDateTime.MIN.toZonedDateTime());
+
+    private final Range<OffsetDateTime> tsTzO = Range.rightOpen(
+            OffsetDateTime.of(LocalDateTime.of(2007, Month.MAY, 3, 10, 15, 30), DEFAULT_OFFSET),
+            OffsetDateTime.of(LocalDateTime.of(2008, Month.MAY, 3, 10, 15, 30), DEFAULT_OFFSET)
+    );
+
+//    private final Range<OffsetDateTime> tsTz0Empty = Range.rightOpen(OffsetDateTime.MIN.toZonedDateTime().)
+
+    private final Range<LocalDate> dateRange = Range.rightOpen(LocalDate.of(1992, Month.JANUARY, 13), LocalDate.of(1995, Month.JANUARY, 13));
+
+    private final Range<LocalDate> dateRangeEmpty = Range.rightOpen(LocalDate.MIN, LocalDate.MIN);
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class[]{
+                Restriction.class
+        };
+    }
+
+    @Test
+    public void test() {
+        Restriction ageRestrictionInt = doInJPA(entityManager -> {
+            entityManager.persist(new Restriction());
+
+            Restriction restriction = new Restriction();
+            restriction.setRangeInt(int4Range);
+            restriction.setRangeIntEmpty(int4RangeEmpty);
+            restriction.setRangeLong(int8Range);
+            restriction.setRangeLongEmpty(int8RangeEmpty);
+            restriction.setRangeBigDecimal(numeric);
+            restriction.setRangeBigDecimalEmpty(numericEmpty);
+            restriction.setRangeLocalDateTime(localDateTimeRange);
+            restriction.setRangeLocalDateTimeEmpty(localDateTimeRangeEmpty);
+            restriction.setRangeZonedDateTime(tsTz);
+            restriction.setRangeZonedDateTimeEmpty(tsTzEmpty);
+            restriction.setRangeLocalDate(dateRange);
+            restriction.setRangeLocalDateEmpty(dateRangeEmpty);
+            restriction.setOffsetZonedDateTime(tsTzO);
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+            assertEquals(int4Range, ar.getRangeInt());
+            assertEquals(int4RangeEmpty, ar.getRangeIntEmpty());
+            assertEquals(int8Range, ar.getRangeLong());
+            assertEquals(int8RangeEmpty, ar.getRangeLongEmpty());
+            assertEquals(numeric, ar.getRangeBigDecimal());
+            assertEquals(numericEmpty, ar.getRangeBigDecimalEmpty());
+            assertEquals(localDateTimeRange, ar.getRangeLocalDateTime());
+            assertEquals(localDateTimeRangeEmpty, ar.getRangeLocalDateTimeEmpty());
+            assertEquals(tsTzO, ar.getOffsetZonedDateTime());
+            assertEquals(dateRange, ar.getRangeLocalDate());
+            assertEquals(dateRangeEmpty, ar.getRangeLocalDateEmpty());
+
+            ZoneId zone = ar.getRangeZonedDateTime().getLowerBound().getValue().get().getZone();
+            ZonedDateTime lower = tsTz.getLowerBound().getValue().get().withZoneSameInstant(zone);
+            ZonedDateTime upper = tsTz.getUpperBound().getValue().get().withZoneSameInstant(zone);
+            assertEquals(ar.getRangeZonedDateTime(), Range.rightOpen(lower, upper));
+
+            ZoneId zoneEmpty = ar.getRangeZonedDateTimeEmpty().getLowerBound().getValue().get().getZone();
+            ZonedDateTime lowerEmpty = tsTzEmpty.getLowerBound().getValue().get().withZoneSameInstant(zoneEmpty);
+            ZonedDateTime upperEmpty = tsTzEmpty.getUpperBound().getValue().get().withZoneSameInstant(zoneEmpty);
+            assertEquals(ar.getRangeZonedDateTimeEmpty(), Range.rightOpen(lowerEmpty, upperEmpty));
+
+        });
+    }
+
+    @Test
+    public void testNullRange() {
+        Restriction ageRestrictionInt = doInJPA(entityManager -> {
+            Restriction restriction = new Restriction();
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+            assertNull(ar.getRangeInt());
+            assertNull(ar.getRangeIntEmpty());
+            assertNull(ar.getRangeLong());
+            assertNull(ar.getRangeLongEmpty());
+            assertNull(ar.getRangeBigDecimal());
+            assertNull(ar.getRangeBigDecimalEmpty());
+            assertNull(ar.getRangeLocalDateTime());
+            assertNull(ar.getRangeLocalDateTimeEmpty());
+            assertNull(ar.getRangeLocalDate());
+            assertNull(ar.getRangeLocalDateEmpty());
+            assertNull(ar.getRangeZonedDateTime());
+            assertNull(ar.getRangeZonedDateTimeEmpty());
+        });
+    }
+
+    @Test
+    public void testUnboundedRangeIsRejected() {
+        Restriction ageRestrictionInt = doInJPA(entityManager -> {
+            Restriction restriction = new Restriction();
+            restriction.setRangeInt(Range.unbounded());
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+            assertEquals(ar.getRangeInt(), Range.unbounded());
+        });
+    }
+
+    @Test
+    public void testUnboundedRangeStringIsRejected() {
+        PostgreSQLSpringRangeType instance = PostgreSQLSpringRangeType.INSTANCE;
+        assertEquals(Range.unbounded(), integerRange("(,)"));
+    }
+
+    @Test
+    public void testSingleBoundedRanges() {
+        PostgreSQLSpringRangeType instance = PostgreSQLSpringRangeType.INSTANCE;
+
+        assertEquals("(,)", instance.asString(Range.unbounded()));
+        assertEquals("(1,)", instance.asString(Range.rightUnbounded(Range.Bound.exclusive(1))));
+        assertEquals("[2,)", instance.asString(Range.rightUnbounded(Range.Bound.inclusive(2))));
+        assertEquals("(,3)", instance.asString(Range.leftUnbounded(Range.Bound.exclusive(3))));
+        assertEquals("(,4]", instance.asString(Range.leftUnbounded(Range.Bound.inclusive(4))));
+
+        assertEquals(Range.rightUnbounded(Range.Bound.exclusive(5)), integerRange("(5,)"));
+        assertEquals(Range.rightUnbounded(Range.Bound.inclusive(6)), integerRange("[6,)"));
+        assertEquals(Range.leftUnbounded(Range.Bound.exclusive(7)), integerRange("(,7)"));
+        assertEquals(Range.leftUnbounded(Range.Bound.inclusive(8)), integerRange("(,8]"));
+    }
+
+    @Entity(name = "AgeRestriction")
+    @Table(name = "age_restriction")
+    public static class Restriction {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_int", columnDefinition = "int4Range")
+        private Range<Integer> rangeInt;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_int_empty", columnDefinition = "int4Range")
+        private Range<Integer> rangeIntEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_long", columnDefinition = "int8range")
+        private Range<Long> rangeLong;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_long_empty", columnDefinition = "int8range")
+        private Range<Long> rangeLongEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_numeric", columnDefinition = "numrange")
+        private Range<BigDecimal> rangeBigDecimal;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_numeric_empty", columnDefinition = "numrange")
+        private Range<BigDecimal> rangeBigDecimalEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_tsrange", columnDefinition = "tsrange")
+        private Range<LocalDateTime> rangeLocalDateTime;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_tsrange_empty", columnDefinition = "tsrange")
+        private Range<LocalDateTime> rangeLocalDateTimeEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_tstzrange", columnDefinition = "tstzrange")
+        private Range<ZonedDateTime> rangeZonedDateTime;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_tstzrange_empty", columnDefinition = "tstzrange")
+        private Range<ZonedDateTime> rangeZonedDateTimeEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_otstzrange", columnDefinition = "tstzrange")
+        private Range<OffsetDateTime> offsetZonedDateTime;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_daterange", columnDefinition = "daterange")
+        private Range<LocalDate> rangeLocalDate;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_daterange_empty", columnDefinition = "daterange")
+        private Range<LocalDate> rangeLocalDateEmpty;
+
+        public Long getId() {
+            return id;
+        }
+
+        public Range<Long> getRangeLong() {
+            return rangeLong;
+        }
+
+        public void setRangeLong(Range<Long> rangeLong) {
+            this.rangeLong = rangeLong;
+        }
+
+        public Range<Long> getRangeLongEmpty() {
+            return rangeLongEmpty;
+        }
+
+        public void setRangeLongEmpty(Range<Long> rangeLongEmpty) {
+            this.rangeLongEmpty = rangeLongEmpty;
+        }
+
+        public Range<Integer> getRangeInt() {
+            return rangeInt;
+        }
+
+        public void setRangeInt(Range<Integer> rangeInt) {
+            this.rangeInt = rangeInt;
+        }
+
+        public Range<Integer> getRangeIntEmpty() {
+            return rangeIntEmpty;
+        }
+
+        public void setRangeIntEmpty(Range<Integer> rangeIntEmpty) {
+            this.rangeIntEmpty = rangeIntEmpty;
+        }
+        
+        public Range<BigDecimal> getRangeBigDecimal() {
+            return rangeBigDecimal;
+        }
+
+        public void setRangeBigDecimal(Range<BigDecimal> rangeBigDecimal) {
+            this.rangeBigDecimal = rangeBigDecimal;
+        }
+
+        public void setRangeLocalDateTime(Range<LocalDateTime> rangeLocalDateTime) {
+            this.rangeLocalDateTime = rangeLocalDateTime;
+        }
+
+        public Range<ZonedDateTime> getRangeZonedDateTime() {
+            return rangeZonedDateTime;
+        }
+
+        public void setRangeZonedDateTime(Range<ZonedDateTime> rangeZonedDateTime) {
+            this.rangeZonedDateTime = rangeZonedDateTime;
+        }
+
+        public Range<LocalDate> getRangeLocalDate() {
+            return rangeLocalDate;
+        }
+
+        public void setRangeLocalDate(Range<LocalDate> localDateRange) {
+            this.rangeLocalDate = localDateRange;
+        }
+
+        public Range<OffsetDateTime> getOffsetZonedDateTime() {
+            return offsetZonedDateTime;
+        }
+
+        public void setOffsetZonedDateTime(Range<OffsetDateTime> offsetZonedDateTime) {
+            this.offsetZonedDateTime = offsetZonedDateTime;
+        }
+
+        public Range<BigDecimal> getRangeBigDecimalEmpty() {
+            return rangeBigDecimalEmpty;
+        }
+
+        public void setRangeBigDecimalEmpty(Range<BigDecimal> rangeBigDecimalEmpty) {
+            this.rangeBigDecimalEmpty = rangeBigDecimalEmpty;
+        }
+
+        public Range<LocalDateTime> getRangeLocalDateTime() {
+            return rangeLocalDateTime;
+        }
+
+        public Range<LocalDateTime> getRangeLocalDateTimeEmpty() {
+            return rangeLocalDateTimeEmpty;
+        }
+
+        public void setRangeLocalDateTimeEmpty(Range<LocalDateTime> rangeLocalDateTimeEmpty) {
+            this.rangeLocalDateTimeEmpty = rangeLocalDateTimeEmpty;
+        }
+
+        public Range<ZonedDateTime> getRangeZonedDateTimeEmpty() {
+            return rangeZonedDateTimeEmpty;
+        }
+
+        public void setRangeZonedDateTimeEmpty(Range<ZonedDateTime> rangeZonedDateTimeEmpty) {
+            this.rangeZonedDateTimeEmpty = rangeZonedDateTimeEmpty;
+        }
+
+        public Range<LocalDate> getRangeLocalDateEmpty() {
+            return rangeLocalDateEmpty;
+        }
+
+        public void setRangeLocalDateEmpty(Range<LocalDate> localDateRangeEmpty) {
+            this.rangeLocalDateEmpty = localDateRangeEmpty;
+        }
+    }
+}

--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/range/spring/PostgreSQLSpringRangeType.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/range/spring/PostgreSQLSpringRangeType.java
@@ -1,0 +1,360 @@
+package io.hypersistence.utils.hibernate.type.range.spring;
+
+import io.hypersistence.utils.common.ReflectionUtils;
+import io.hypersistence.utils.hibernate.type.ImmutableType;
+import org.hibernate.HibernateException;
+import org.hibernate.annotations.common.reflection.XProperty;
+import org.hibernate.annotations.common.reflection.java.JavaXMember;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.usertype.DynamicParameterizedType;
+import org.springframework.data.domain.Range;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.util.Properties;
+import java.util.function.Function;
+
+public class PostgreSQLSpringRangeType extends ImmutableType<Range> implements DynamicParameterizedType {
+
+    private static final Range<Integer> EMPTY_INT_RANGE = Range.rightOpen(Integer.MIN_VALUE, Integer.MIN_VALUE);
+    
+    private static final Range<Long> EMPTY_LONG_RANGE = Range.rightOpen(Long.MIN_VALUE, Long.MIN_VALUE);
+    
+    private static final Range<BigDecimal> EMPTY_BIGDECIMAL_RANGE = Range.rightOpen(BigDecimal.ZERO, BigDecimal.ZERO);
+    
+    private static final Range<LocalDateTime> EMPTY_LOCALDATETIME_RANGE = Range.rightOpen(LocalDateTime.MIN, LocalDateTime.MIN);
+    
+    private static final Range<OffsetDateTime> EMPTY_OFFSETDATETIME_RANGE = Range.rightOpen(OffsetDateTime.MIN, OffsetDateTime.MIN);
+    
+    private static final Range<ZonedDateTime> EMPTY_ZONEDDATETIME_RANGE = Range.rightOpen(OffsetDateTime.MIN.toZonedDateTime(), OffsetDateTime.MIN.toZonedDateTime());
+    
+    private static final Range<LocalDate> EMPTY_DATE_RANGE = Range.rightOpen(LocalDate.MIN, LocalDate.MIN);
+
+    private static final DateTimeFormatter LOCAL_DATE_TIME = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH:mm:ss")
+            .optionalStart()
+            .appendPattern(".")
+            .appendFraction(ChronoField.NANO_OF_SECOND, 1, 6, false)
+            .optionalEnd()
+            .toFormatter();
+
+    private static final DateTimeFormatter OFFSET_DATE_TIME = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH:mm:ss")
+            .optionalStart()
+            .appendPattern(".")
+            .appendFraction(ChronoField.NANO_OF_SECOND, 1, 6, false)
+            .optionalEnd()
+            .appendPattern("X")
+            .toFormatter();
+
+    public static final PostgreSQLSpringRangeType INSTANCE = new PostgreSQLSpringRangeType();
+
+    private Type type;
+
+    private Class<?> elementType;
+
+    public PostgreSQLSpringRangeType() {
+        super(Range.class);
+    }
+
+    public PostgreSQLSpringRangeType(Class<?> elementType) {
+        super(Range.class);
+        this.elementType = elementType;
+    }
+    
+    @Override
+    protected Range get(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+        Object pgObject = rs.getObject(position);
+
+        if (pgObject == null) {
+            return null;
+        }
+
+        String type = ReflectionUtils.invokeGetter(pgObject, "type");
+        String value = ReflectionUtils.invokeGetter(pgObject, "value");
+
+        switch (type) {
+            case "int4range":
+                return integerRange(value);
+            case "int8range":
+                return longRange(value);
+            case "numrange":
+                return bigDecimalRange(value);
+            case "tsrange":
+                return localDateTimeRange(value);
+            case "tstzrange":
+                return ZonedDateTime.class.equals(elementType) ? zonedDateTimeRange(value) : offsetDateTimeRange(value);
+            case "daterange":
+                return localDateRange(value);
+            default:
+                throw new HibernateException(
+                        new IllegalStateException("The range type [" + type + "] is not supported!")
+                );
+        }
+    }
+
+    @Override
+    protected void set(PreparedStatement st, Range range, int index, SharedSessionContractImplementor session) throws SQLException {
+        if (range == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
+            ReflectionUtils.invokeSetter(holder, "type", determineRangeType(range));
+            ReflectionUtils.invokeSetter(holder, "value", asString(range));
+            st.setObject(index, holder);
+        }
+    }
+
+    @Override
+    public Range fromStringValue(CharSequence sequence) throws HibernateException {
+        if (sequence != null) {
+            String stringValue = (String) sequence;
+            Class clazz = rangeClass();
+            if (clazz != null) {
+                if (Integer.class.isAssignableFrom(clazz)) {
+                    return integerRange(stringValue);
+                }
+                if (Long.class.isAssignableFrom(clazz)) {
+                    return longRange(stringValue);
+                }
+                if (BigDecimal.class.isAssignableFrom(clazz)) {
+                    return bigDecimalRange(stringValue);
+                }
+                if (LocalDateTime.class.isAssignableFrom(clazz)) {
+                    return localDateTimeRange(stringValue);
+                }
+                if (ZonedDateTime.class.isAssignableFrom(clazz)) {
+                    return zonedDateTimeRange(stringValue);
+                }
+                if (LocalDate.class.isAssignableFrom(clazz)) {
+                    return localDateRange(stringValue);
+                }
+                throw new HibernateException(
+                        new IllegalStateException("The range type [" + type + "] is not supported!")
+                );
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void setParameterValues(Properties properties) {
+        final XProperty xProperty = (XProperty) properties.get(DynamicParameterizedType.XPROPERTY);
+        if (xProperty instanceof JavaXMember) {
+            type = ((JavaXMember) xProperty).getJavaType();
+        } else {
+            type = ((ParameterType) properties.get(PARAMETER_TYPE)).getReturnedClass();
+        }
+
+        if (type instanceof ParameterizedType) {
+            elementType = (Class<?>) ((ParameterizedType) type).getActualTypeArguments()[0];
+        }
+    }
+
+    @Override
+    public int getSqlType() {
+        return Types.OTHER;
+    }
+
+    private String determineRangeType(Range<?> range) {
+        Type clazz = this.elementType;
+
+        if (clazz.equals(Integer.class)) {
+            return "int4range";
+        } else if (clazz.equals(Long.class)) {
+            return "int8range";
+        } else if (clazz.equals(BigDecimal.class)) {
+            return "numrange";
+        } else if (clazz.equals(LocalDateTime.class)) {
+            return "tsrange";
+        } else if (clazz.equals(ZonedDateTime.class) || clazz.equals(OffsetDateTime.class)) {
+            return "tstzrange";
+        } else if (clazz.equals(LocalDate.class)) {
+            return "daterange";
+        }
+
+        throw new HibernateException(
+                new IllegalStateException("The class [" + clazz + "] is not supported!")
+        );
+    }
+
+    public static <T extends Comparable<?>> Range<T> ofString(String str, Function<String, T> converter, Class<T> clazz) {
+        if ("empty".equals(str)) {
+            if (clazz.equals(Integer.class)) {
+                return (Range<T>) EMPTY_INT_RANGE;
+            } else if (clazz.equals(Long.class)) {
+                return (Range<T>) EMPTY_LONG_RANGE;
+            } else if (clazz.equals(BigDecimal.class)) {
+                return (Range<T>) EMPTY_BIGDECIMAL_RANGE;
+            } else if (clazz.equals(LocalDateTime.class)) {
+                return (Range<T>) EMPTY_LOCALDATETIME_RANGE;
+            } else if (clazz.equals(ZonedDateTime.class)) {
+                return (Range<T>) EMPTY_ZONEDDATETIME_RANGE;
+            } else if (clazz.equals(OffsetDateTime.class)) {
+                return (Range<T>) EMPTY_OFFSETDATETIME_RANGE;
+            } else if (clazz.equals(LocalDate.class)) {
+                return (Range<T>) EMPTY_DATE_RANGE;
+            }
+        }
+
+        int delim = str.indexOf(',');
+
+        if (delim == -1) {
+            throw new HibernateException(
+                    new IllegalArgumentException("Cannot find comma character")
+            );
+        }
+
+        String lowerStr = str.substring(1, delim);
+        String upperStr = str.substring(delim + 1, str.length() - 1);
+
+        Range.Bound<T> lowerBound =  Range.Bound.unbounded();
+        Range.Bound<T> upperBound = Range.Bound.unbounded();
+
+        if (!lowerStr.isEmpty()) {
+            T lower = converter.apply(lowerStr);
+            lowerBound = str.charAt(0) == '[' ? Range.Bound.inclusive(lower) : Range.Bound.exclusive(lower);
+        }
+
+        if (!upperStr.isEmpty()) {
+            T upper = converter.apply(upperStr);
+            upperBound = str.charAt(str.length() - 1) == ']' ? Range.Bound.inclusive(upper) : Range.Bound.exclusive(upper);
+        }
+
+        return Range.of(lowerBound, upperBound);
+
+    }
+
+    public static Range<BigDecimal> bigDecimalRange(String range) {
+        return ofString(range, BigDecimal::new, BigDecimal.class);
+    }
+
+    public static Range<Integer> integerRange(String range) {
+        return ofString(range, Integer::parseInt, Integer.class);
+    }
+
+    public static Range<Long> longRange(String range) {
+        return ofString(range, Long::parseLong, Long.class);
+    }
+
+    public static Range<LocalDateTime> localDateTimeRange(String range) {
+        return ofString(range, parseLocalDateTime().compose(unquote()), LocalDateTime.class);
+    }
+
+    public static Range<LocalDate> localDateRange(String range) {
+        Function<String, LocalDate> parseLocalDate = LocalDate::parse;
+        return ofString(range, parseLocalDate.compose(unquote()), LocalDate.class);
+    }
+
+    public static Range<ZonedDateTime> zonedDateTimeRange(String rangeStr) {
+        Range<ZonedDateTime> range = ofString(rangeStr, parseZonedDateTime().compose(unquote()), ZonedDateTime.class);
+        if (range.getLowerBound().isBounded() && range.getUpperBound().isBounded()) {
+            ZoneId lowerZone = range.getLowerBound().getValue().get().getZone();
+            ZoneId upperZone = range.getUpperBound().getValue().get().getZone();
+            if (!lowerZone.equals(upperZone)) {
+                Duration lowerDst = ZoneId.systemDefault().getRules().getDaylightSavings(range.getLowerBound().getValue().get().toInstant());
+                Duration upperDst = ZoneId.systemDefault().getRules().getDaylightSavings(range.getUpperBound().getValue().get().toInstant());
+                long dstSeconds = upperDst.minus(lowerDst).getSeconds();
+                if (dstSeconds < 0) {
+                    dstSeconds *= -1;
+                }
+                long zoneDriftSeconds = ((ZoneOffset) lowerZone).getTotalSeconds() - ((ZoneOffset) upperZone).getTotalSeconds();
+                if (zoneDriftSeconds < 0) {
+                    zoneDriftSeconds *= -1;
+                }
+
+                if (dstSeconds != zoneDriftSeconds) {
+                    throw new HibernateException(
+                            new IllegalArgumentException("The upper and lower bounds must be in same time zone!")
+                    );
+                }
+            }
+        }
+        return range;
+    }
+
+    public static Range<OffsetDateTime> offsetDateTimeRange(String rangeStr) {
+        return ofString(rangeStr, parseOffsetDateTime().compose(unquote()), OffsetDateTime.class);
+    }
+
+    private static Function<String, LocalDateTime> parseLocalDateTime() {
+        return str -> {
+            try {
+                return LocalDateTime.parse(str, LOCAL_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                return LocalDateTime.parse(str);
+            }
+        };
+    }
+
+    private static Function<String, ZonedDateTime> parseZonedDateTime() {
+        return s -> {
+            try {
+                return ZonedDateTime.parse(s, OFFSET_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                return ZonedDateTime.parse(s);
+            }
+        };
+    }
+
+    private static Function<String, OffsetDateTime> parseOffsetDateTime() {
+        return s -> {
+            try {
+                return OffsetDateTime.parse(s, OFFSET_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                return OffsetDateTime.parse(s);
+            }
+        };
+    }
+
+    private static Function<String, String> unquote() {
+        return s -> {
+            if (s.charAt(0) == '\"' && s.charAt(s.length() - 1) == '\"') {
+                return s.substring(1, s.length() - 1);
+            }
+
+            return s;
+        };
+    }
+
+    String asString(Range<?> range) {
+
+        if (!range.getLowerBound().isBounded() && !range.getUpperBound().isBounded()) {
+            return "(,)";
+        }
+        if (range.getLowerBound().getValue().equals(range.getUpperBound().getValue())) {
+            return "empty";
+        }
+
+        Range.Bound<?> lower = range.getLowerBound();
+        Range.Bound<?> upper = range.getUpperBound();
+
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(lower.isBounded() ? lower.isInclusive() ? "[" : "(" : "(");
+        lower.getValue().ifPresent(sb::append);
+        sb.append(",");
+        upper.getValue().ifPresent(sb::append);
+        sb.append(upper.isBounded() ? upper.isInclusive() ? "]": ")": ")");
+
+        return sb.toString();
+    }
+
+    private Class rangeClass() {
+            if (type instanceof ParameterizedType) {
+                Type[] types = ((ParameterizedType) type).getActualTypeArguments();
+                return (Class) types[0];
+            }
+            return null;
+        }
+}

--- a/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/type/range/spring/PostgreSQLSpringRangeTypeTest.java
+++ b/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/type/range/spring/PostgreSQLSpringRangeTypeTest.java
@@ -1,0 +1,348 @@
+package io.hypersistence.utils.hibernate.type.range.spring;
+
+import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+import org.springframework.data.domain.Range;
+
+import java.math.BigDecimal;
+import java.time.*;
+
+import static io.hypersistence.utils.hibernate.type.range.spring.PostgreSQLSpringRangeType.integerRange;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class PostgreSQLSpringRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    private static final ZoneOffset DEFAULT_OFFSET = OffsetDateTime.now().getOffset();
+
+    private final Range<BigDecimal> numeric = Range.rightOpen(new BigDecimal("0.5"), new BigDecimal("0.89"));
+
+    private final Range<BigDecimal> numericEmpty = Range.rightOpen(BigDecimal.ZERO, BigDecimal.ZERO);
+
+    private final Range<Long> int8Range = Range.rightOpen(0L, 18L);
+
+    private final Range<Long> int8RangeEmpty = Range.rightOpen(Long.MIN_VALUE, Long.MIN_VALUE);
+
+    private final Range<Integer> int4Range = Range.rightOpen(0, 18);
+
+    private final Range<Integer> int4RangeEmpty = Range.rightOpen(Integer.MIN_VALUE, Integer.MIN_VALUE);
+
+    private final Range<LocalDateTime> localDateTimeRange = Range.rightOpen(
+            LocalDateTime.of(2014, Month.APRIL, 28, 16, 0, 49),
+            LocalDateTime.of(2015, Month.APRIL, 28, 16, 0, 49));
+
+    private final Range<LocalDateTime> localDateTimeRangeEmpty = Range.rightOpen(LocalDateTime.MIN, LocalDateTime.MIN);
+
+    private final Range<ZonedDateTime> tsTz = Range.rightOpen(
+            OffsetDateTime.of(LocalDateTime.of(2007, Month.DECEMBER, 3, 10, 15, 30), ZoneOffset.ofHours(1)).toZonedDateTime(),
+            OffsetDateTime.of(LocalDateTime.of(2008, Month.DECEMBER, 3, 10, 15, 30), ZoneOffset.ofHours(1)).toZonedDateTime());
+
+    private final Range<ZonedDateTime> tsTzEmpty = Range.rightOpen(OffsetDateTime.MIN.toZonedDateTime(), OffsetDateTime.MIN.toZonedDateTime());
+
+    private final Range<OffsetDateTime> tsTzO = Range.rightOpen(
+            OffsetDateTime.of(LocalDateTime.of(2007, Month.MAY, 3, 10, 15, 30), DEFAULT_OFFSET),
+            OffsetDateTime.of(LocalDateTime.of(2008, Month.MAY, 3, 10, 15, 30), DEFAULT_OFFSET)
+    );
+
+//    private final Range<OffsetDateTime> tsTz0Empty = Range.rightOpen(OffsetDateTime.MIN.toZonedDateTime().)
+
+    private final Range<LocalDate> dateRange = Range.rightOpen(LocalDate.of(1992, Month.JANUARY, 13), LocalDate.of(1995, Month.JANUARY, 13));
+
+    private final Range<LocalDate> dateRangeEmpty = Range.rightOpen(LocalDate.MIN, LocalDate.MIN);
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class[]{
+                Restriction.class
+        };
+    }
+
+    @Test
+    public void test() {
+        Restriction ageRestrictionInt = doInJPA(entityManager -> {
+            entityManager.persist(new Restriction());
+
+            Restriction restriction = new Restriction();
+            restriction.setRangeInt(int4Range);
+            restriction.setRangeIntEmpty(int4RangeEmpty);
+            restriction.setRangeLong(int8Range);
+            restriction.setRangeLongEmpty(int8RangeEmpty);
+            restriction.setRangeBigDecimal(numeric);
+            restriction.setRangeBigDecimalEmpty(numericEmpty);
+            restriction.setRangeLocalDateTime(localDateTimeRange);
+            restriction.setRangeLocalDateTimeEmpty(localDateTimeRangeEmpty);
+            restriction.setRangeZonedDateTime(tsTz);
+            restriction.setRangeZonedDateTimeEmpty(tsTzEmpty);
+            restriction.setRangeLocalDate(dateRange);
+            restriction.setRangeLocalDateEmpty(dateRangeEmpty);
+            restriction.setOffsetZonedDateTime(tsTzO);
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+            assertEquals(int4Range, ar.getRangeInt());
+            assertEquals(int4RangeEmpty, ar.getRangeIntEmpty());
+            assertEquals(int8Range, ar.getRangeLong());
+            assertEquals(int8RangeEmpty, ar.getRangeLongEmpty());
+            assertEquals(numeric, ar.getRangeBigDecimal());
+            assertEquals(numericEmpty, ar.getRangeBigDecimalEmpty());
+            assertEquals(localDateTimeRange, ar.getRangeLocalDateTime());
+            assertEquals(localDateTimeRangeEmpty, ar.getRangeLocalDateTimeEmpty());
+            assertEquals(tsTzO, ar.getOffsetZonedDateTime());
+            assertEquals(dateRange, ar.getRangeLocalDate());
+            assertEquals(dateRangeEmpty, ar.getRangeLocalDateEmpty());
+
+            ZoneId zone = ar.getRangeZonedDateTime().getLowerBound().getValue().get().getZone();
+            ZonedDateTime lower = tsTz.getLowerBound().getValue().get().withZoneSameInstant(zone);
+            ZonedDateTime upper = tsTz.getUpperBound().getValue().get().withZoneSameInstant(zone);
+            assertEquals(ar.getRangeZonedDateTime(), Range.rightOpen(lower, upper));
+
+            ZoneId zoneEmpty = ar.getRangeZonedDateTimeEmpty().getLowerBound().getValue().get().getZone();
+            ZonedDateTime lowerEmpty = tsTzEmpty.getLowerBound().getValue().get().withZoneSameInstant(zoneEmpty);
+            ZonedDateTime upperEmpty = tsTzEmpty.getUpperBound().getValue().get().withZoneSameInstant(zoneEmpty);
+            assertEquals(ar.getRangeZonedDateTimeEmpty(), Range.rightOpen(lowerEmpty, upperEmpty));
+
+        });
+    }
+
+    @Test
+    public void testNullRange() {
+        Restriction ageRestrictionInt = doInJPA(entityManager -> {
+            Restriction restriction = new Restriction();
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+            assertNull(ar.getRangeInt());
+            assertNull(ar.getRangeIntEmpty());
+            assertNull(ar.getRangeLong());
+            assertNull(ar.getRangeLongEmpty());
+            assertNull(ar.getRangeBigDecimal());
+            assertNull(ar.getRangeBigDecimalEmpty());
+            assertNull(ar.getRangeLocalDateTime());
+            assertNull(ar.getRangeLocalDateTimeEmpty());
+            assertNull(ar.getRangeLocalDate());
+            assertNull(ar.getRangeLocalDateEmpty());
+            assertNull(ar.getRangeZonedDateTime());
+            assertNull(ar.getRangeZonedDateTimeEmpty());
+        });
+    }
+
+    @Test
+    public void testUnboundedRangeIsRejected() {
+        Restriction ageRestrictionInt = doInJPA(entityManager -> {
+            Restriction restriction = new Restriction();
+            restriction.setRangeInt(Range.unbounded());
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+            assertEquals(ar.getRangeInt(), Range.unbounded());
+        });
+    }
+
+    @Test
+    public void testUnboundedRangeStringIsRejected() {
+        PostgreSQLSpringRangeType instance = PostgreSQLSpringRangeType.INSTANCE;
+        assertEquals(Range.unbounded(), integerRange("(,)"));
+    }
+
+    @Test
+    public void testSingleBoundedRanges() {
+        PostgreSQLSpringRangeType instance = PostgreSQLSpringRangeType.INSTANCE;
+
+        assertEquals("(,)", instance.asString(Range.unbounded()));
+        assertEquals("(1,)", instance.asString(Range.rightUnbounded(Range.Bound.exclusive(1))));
+        assertEquals("[2,)", instance.asString(Range.rightUnbounded(Range.Bound.inclusive(2))));
+        assertEquals("(,3)", instance.asString(Range.leftUnbounded(Range.Bound.exclusive(3))));
+        assertEquals("(,4]", instance.asString(Range.leftUnbounded(Range.Bound.inclusive(4))));
+
+        assertEquals(Range.rightUnbounded(Range.Bound.exclusive(5)), integerRange("(5,)"));
+        assertEquals(Range.rightUnbounded(Range.Bound.inclusive(6)), integerRange("[6,)"));
+        assertEquals(Range.leftUnbounded(Range.Bound.exclusive(7)), integerRange("(,7)"));
+        assertEquals(Range.leftUnbounded(Range.Bound.inclusive(8)), integerRange("(,8]"));
+    }
+
+    @Entity(name = "AgeRestriction")
+    @Table(name = "age_restriction")
+    public static class Restriction {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_int", columnDefinition = "int4Range")
+        private Range<Integer> rangeInt;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_int_empty", columnDefinition = "int4Range")
+        private Range<Integer> rangeIntEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_long", columnDefinition = "int8range")
+        private Range<Long> rangeLong;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_long_empty", columnDefinition = "int8range")
+        private Range<Long> rangeLongEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_numeric", columnDefinition = "numrange")
+        private Range<BigDecimal> rangeBigDecimal;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_numeric_empty", columnDefinition = "numrange")
+        private Range<BigDecimal> rangeBigDecimalEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_tsrange", columnDefinition = "tsrange")
+        private Range<LocalDateTime> rangeLocalDateTime;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_tsrange_empty", columnDefinition = "tsrange")
+        private Range<LocalDateTime> rangeLocalDateTimeEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_tstzrange", columnDefinition = "tstzrange")
+        private Range<ZonedDateTime> rangeZonedDateTime;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_tstzrange_empty", columnDefinition = "tstzrange")
+        private Range<ZonedDateTime> rangeZonedDateTimeEmpty;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_otstzrange", columnDefinition = "tstzrange")
+        private Range<OffsetDateTime> offsetZonedDateTime;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_daterange", columnDefinition = "daterange")
+        private Range<LocalDate> rangeLocalDate;
+
+        @Type(PostgreSQLSpringRangeType.class)
+        @Column(name = "r_daterange_empty", columnDefinition = "daterange")
+        private Range<LocalDate> rangeLocalDateEmpty;
+
+        public Long getId() {
+            return id;
+        }
+
+        public Range<Long> getRangeLong() {
+            return rangeLong;
+        }
+
+        public void setRangeLong(Range<Long> rangeLong) {
+            this.rangeLong = rangeLong;
+        }
+
+        public Range<Long> getRangeLongEmpty() {
+            return rangeLongEmpty;
+        }
+
+        public void setRangeLongEmpty(Range<Long> rangeLongEmpty) {
+            this.rangeLongEmpty = rangeLongEmpty;
+        }
+
+        public Range<Integer> getRangeInt() {
+            return rangeInt;
+        }
+
+        public void setRangeInt(Range<Integer> rangeInt) {
+            this.rangeInt = rangeInt;
+        }
+
+        public Range<Integer> getRangeIntEmpty() {
+            return rangeIntEmpty;
+        }
+
+        public void setRangeIntEmpty(Range<Integer> rangeIntEmpty) {
+            this.rangeIntEmpty = rangeIntEmpty;
+        }
+        
+        public Range<BigDecimal> getRangeBigDecimal() {
+            return rangeBigDecimal;
+        }
+
+        public void setRangeBigDecimal(Range<BigDecimal> rangeBigDecimal) {
+            this.rangeBigDecimal = rangeBigDecimal;
+        }
+
+        public void setRangeLocalDateTime(Range<LocalDateTime> rangeLocalDateTime) {
+            this.rangeLocalDateTime = rangeLocalDateTime;
+        }
+
+        public Range<ZonedDateTime> getRangeZonedDateTime() {
+            return rangeZonedDateTime;
+        }
+
+        public void setRangeZonedDateTime(Range<ZonedDateTime> rangeZonedDateTime) {
+            this.rangeZonedDateTime = rangeZonedDateTime;
+        }
+
+        public Range<LocalDate> getRangeLocalDate() {
+            return rangeLocalDate;
+        }
+
+        public void setRangeLocalDate(Range<LocalDate> localDateRange) {
+            this.rangeLocalDate = localDateRange;
+        }
+
+        public Range<OffsetDateTime> getOffsetZonedDateTime() {
+            return offsetZonedDateTime;
+        }
+
+        public void setOffsetZonedDateTime(Range<OffsetDateTime> offsetZonedDateTime) {
+            this.offsetZonedDateTime = offsetZonedDateTime;
+        }
+
+        public Range<BigDecimal> getRangeBigDecimalEmpty() {
+            return rangeBigDecimalEmpty;
+        }
+
+        public void setRangeBigDecimalEmpty(Range<BigDecimal> rangeBigDecimalEmpty) {
+            this.rangeBigDecimalEmpty = rangeBigDecimalEmpty;
+        }
+
+        public Range<LocalDateTime> getRangeLocalDateTime() {
+            return rangeLocalDateTime;
+        }
+
+        public Range<LocalDateTime> getRangeLocalDateTimeEmpty() {
+            return rangeLocalDateTimeEmpty;
+        }
+
+        public void setRangeLocalDateTimeEmpty(Range<LocalDateTime> rangeLocalDateTimeEmpty) {
+            this.rangeLocalDateTimeEmpty = rangeLocalDateTimeEmpty;
+        }
+
+        public Range<ZonedDateTime> getRangeZonedDateTimeEmpty() {
+            return rangeZonedDateTimeEmpty;
+        }
+
+        public void setRangeZonedDateTimeEmpty(Range<ZonedDateTime> rangeZonedDateTimeEmpty) {
+            this.rangeZonedDateTimeEmpty = rangeZonedDateTimeEmpty;
+        }
+
+        public Range<LocalDate> getRangeLocalDateEmpty() {
+            return rangeLocalDateEmpty;
+        }
+
+        public void setRangeLocalDateEmpty(Range<LocalDate> localDateRangeEmpty) {
+            this.rangeLocalDateEmpty = localDateRangeEmpty;
+        }
+    }
+}


### PR DESCRIPTION
Currently, to map the range Hibernate types, there are already 2 options

- Range class from Hypersistence Utils
- Range class from Guava

I would like to add Range class from the Spring Data as a third option.
This would facilitate using the same Range class for use with Spring Data JPA and Spring Data Elasticsearch and perhaps in other Spring Data projects.

The changes with tests are made only to the 6x modules, as the 5x modules uses the Spring Data commons 2.7x where the version of the Range class is incompatible when using Date/Time types e.g. LocalDate, ZonedDateTime etc.
