### PR TITLE
fix any value of enable_types_contributor is treated as false

### DIFF
--- a/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
+++ b/hypersistence-utils-hibernate-52/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
@@ -45,7 +45,7 @@ public class HibernateTypesContributor implements TypeContributor {
                 return value;
             }
             if(value instanceof String) {
-                return Boolean.getBoolean((String) value);
+                return Boolean.valueOf((String) value);
             }
             throw new HibernateException(
                 String.format("The value [%s] of the [%s] setting is not supported!", value, ENABLE_TYPES_CONTRIBUTOR)

--- a/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
+++ b/hypersistence-utils-hibernate-55/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
@@ -45,7 +45,7 @@ public class HibernateTypesContributor implements TypeContributor {
                 return value;
             }
             if(value instanceof String) {
-                return Boolean.getBoolean((String) value);
+                return Boolean.valueOf((String) value);
             }
             throw new HibernateException(
                 String.format("The value [%s] of the [%s] setting is not supported!", value, ENABLE_TYPES_CONTRIBUTOR)

--- a/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
+++ b/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
@@ -43,7 +43,7 @@ public class HibernateTypesContributor implements TypeContributor {
                 return value;
             }
             if(value instanceof String) {
-                return Boolean.getBoolean((String) value);
+                return Boolean.valueOf((String) value);
             }
             throw new HibernateException(
                 String.format("The value [%s] of the [%s] setting is not supported!", value, ENABLE_TYPES_CONTRIBUTOR)

--- a/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/hibernate/util/AbstractPostgreSQLIntegrationTest.java
+++ b/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/hibernate/util/AbstractPostgreSQLIntegrationTest.java
@@ -1,6 +1,5 @@
 package io.hypersistence.utils.hibernate.util;
 
-import io.hypersistence.utils.hibernate.util.AbstractTest;
 import io.hypersistence.utils.test.providers.DataSourceProvider;
 import io.hypersistence.utils.hibernate.util.providers.PostgreSQLDataSourceProvider;
 

--- a/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/hibernate/util/contributor/TypeContributorToggleTest.java
+++ b/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/hibernate/util/contributor/TypeContributorToggleTest.java
@@ -1,0 +1,30 @@
+package io.hypersistence.utils.hibernate.util.contributor;
+
+import io.hypersistence.utils.hibernate.type.HibernateTypesContributor;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+@RunWith(Enclosed.class)
+public class TypeContributorToggleTest {
+    public static class TypeContributorEnabledSettingValueTrueTest extends TypeContributorEnableTest {
+        @Override
+        protected void additionalProperties(Properties properties) {
+            properties.setProperty(
+                    HibernateTypesContributor.ENABLE_TYPES_CONTRIBUTOR,
+                    Boolean.TRUE.toString()
+            );
+        }
+    }
+
+    public static class TypeContributorDisabledSettingValueArbitraryStringTest extends TypeContributorDisableTest {
+        @Override
+        protected void additionalProperties(Properties properties) {
+            properties.setProperty(
+                    HibernateTypesContributor.ENABLE_TYPES_CONTRIBUTOR,
+                    "arbitrary"
+            );
+        }
+    }
+}

--- a/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
+++ b/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
@@ -2,7 +2,6 @@ package io.hypersistence.utils.hibernate.type;
 
 import io.hypersistence.utils.hibernate.type.array.*;
 import io.hypersistence.utils.hibernate.type.basic.Iso8601MonthType;
-import io.hypersistence.utils.hibernate.type.basic.NullableCharacterType;
 import io.hypersistence.utils.hibernate.type.basic.PostgreSQLHStoreType;
 import io.hypersistence.utils.hibernate.type.basic.PostgreSQLInetType;
 import io.hypersistence.utils.hibernate.type.interval.OracleIntervalDayToSecondType;
@@ -46,7 +45,7 @@ public class HibernateTypesContributor implements TypeContributor {
                 return value;
             }
             if(value instanceof String) {
-                return Boolean.getBoolean((String) value);
+                return Boolean.valueOf((String) value);
             }
             throw new HibernateException(
                 String.format("The value [%s] of the [%s] setting is not supported!", value, ENABLE_TYPES_CONTRIBUTOR)

--- a/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/util/AbstractPostgreSQLIntegrationTest.java
+++ b/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/util/AbstractPostgreSQLIntegrationTest.java
@@ -1,6 +1,5 @@
 package io.hypersistence.utils.hibernate.util;
 
-import io.hypersistence.utils.hibernate.util.AbstractTest;
 import io.hypersistence.utils.test.providers.DataSourceProvider;
 import io.hypersistence.utils.hibernate.util.providers.PostgreSQLDataSourceProvider;
 

--- a/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/util/contributor/TypeContributorEnableTest.java
+++ b/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/util/contributor/TypeContributorEnableTest.java
@@ -1,6 +1,5 @@
 package io.hypersistence.utils.hibernate.util.contributor;
 
-import io.hypersistence.utils.hibernate.type.HibernateTypesContributor;
 import io.hypersistence.utils.hibernate.type.basic.Inet;
 import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
 import jakarta.persistence.Column;
@@ -8,8 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import org.junit.Test;
-
-import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 

--- a/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/util/contributor/TypeContributorToggleTest.java
+++ b/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/util/contributor/TypeContributorToggleTest.java
@@ -1,0 +1,30 @@
+package io.hypersistence.utils.hibernate.util.contributor;
+
+import io.hypersistence.utils.hibernate.type.HibernateTypesContributor;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+@RunWith(Enclosed.class)
+public class TypeContributorToggleTest {
+    public static class TypeContributorEnabledSettingValueTrueTest extends TypeContributorEnableTest {
+        @Override
+        protected void additionalProperties(Properties properties) {
+            properties.setProperty(
+                    HibernateTypesContributor.ENABLE_TYPES_CONTRIBUTOR,
+                    Boolean.TRUE.toString()
+            );
+        }
+    }
+
+    public static class TypeContributorDisabledSettingValueArbitraryStringTest extends TypeContributorDisableTest {
+        @Override
+        protected void additionalProperties(Properties properties) {
+            properties.setProperty(
+                    HibernateTypesContributor.ENABLE_TYPES_CONTRIBUTOR,
+                    "arbitrary"
+            );
+        }
+    }
+}

--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
@@ -2,7 +2,6 @@ package io.hypersistence.utils.hibernate.type;
 
 import io.hypersistence.utils.common.ReflectionUtils;
 import io.hypersistence.utils.hibernate.type.basic.Iso8601MonthType;
-import io.hypersistence.utils.hibernate.type.basic.NullableCharacterType;
 import io.hypersistence.utils.hibernate.type.basic.PostgreSQLHStoreType;
 import io.hypersistence.utils.hibernate.type.basic.PostgreSQLInetType;
 import io.hypersistence.utils.hibernate.type.interval.OracleIntervalDayToSecondType;
@@ -45,7 +44,7 @@ public class HibernateTypesContributor implements TypeContributor {
                 return value;
             }
             if(value instanceof String) {
-                return Boolean.getBoolean((String) value);
+                return Boolean.valueOf((String) value);
             }
             throw new HibernateException(
                 String.format("The value [%s] of the [%s] setting is not supported!", value, ENABLE_TYPES_CONTRIBUTOR)

--- a/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/util/AbstractPostgreSQLIntegrationTest.java
+++ b/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/util/AbstractPostgreSQLIntegrationTest.java
@@ -1,6 +1,5 @@
 package io.hypersistence.utils.hibernate.util;
 
-import io.hypersistence.utils.hibernate.util.AbstractTest;
 import io.hypersistence.utils.test.providers.DataSourceProvider;
 import io.hypersistence.utils.hibernate.util.providers.PostgreSQLDataSourceProvider;
 

--- a/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/util/contributor/TypeContributorEnableTest.java
+++ b/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/util/contributor/TypeContributorEnableTest.java
@@ -1,6 +1,5 @@
 package io.hypersistence.utils.hibernate.util.contributor;
 
-import io.hypersistence.utils.hibernate.type.HibernateTypesContributor;
 import io.hypersistence.utils.hibernate.type.basic.Inet;
 import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
 import jakarta.persistence.Column;
@@ -8,8 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import org.junit.Test;
-
-import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 

--- a/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/util/contributor/TypeContributorToggleTest.java
+++ b/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/util/contributor/TypeContributorToggleTest.java
@@ -1,0 +1,30 @@
+package io.hypersistence.utils.hibernate.util.contributor;
+
+import io.hypersistence.utils.hibernate.type.HibernateTypesContributor;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+@RunWith(Enclosed.class)
+public class TypeContributorToggleTest {
+    public static class TypeContributorEnabledSettingValueTrueTest extends TypeContributorEnableTest {
+        @Override
+        protected void additionalProperties(Properties properties) {
+            properties.setProperty(
+                    HibernateTypesContributor.ENABLE_TYPES_CONTRIBUTOR,
+                    Boolean.TRUE.toString()
+            );
+        }
+    }
+
+    public static class TypeContributorDisabledSettingValueArbitraryStringTest extends TypeContributorDisableTest {
+        @Override
+        protected void additionalProperties(Properties properties) {
+            properties.setProperty(
+                    HibernateTypesContributor.ENABLE_TYPES_CONTRIBUTOR,
+                    "arbitrary"
+            );
+        }
+    }
+}


### PR DESCRIPTION
check  https://github.com/vladmihalcea/hypersistence-utils/pull/718 . 
Reply to comments before closing the pull request or give the opportunity to reopen the pull request.
You claim that there is no difference, but there is.
Look at the implementation of getBoolean and look at my test cases
public static boolean getBoolean(String name) {
boolean result = false;
try {
result = parseBoolean(System.getProperty(name));
} catch (IllegalArgumentException | NullPointerException e) {
}
return result;
}
getBoolean parses a system property, not a specific string.
![image](https://github.com/vladmihalcea/hypersistence-utils/assets/55021692/ec8f94a1-2b17-49af-9efa-5b6be77f9f78)
![image](https://github.com/vladmihalcea/hypersistence-utils/assets/55021692/aaa66d5c-0103-46bb-87bc-65bd5d1d20ae)
