### PR TITLE
feat: Json CLOB support for Hibernate 6.x

### DIFF
--- a/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonClobType.java
+++ b/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonClobType.java
@@ -1,0 +1,96 @@
+package io.hypersistence.utils.hibernate.type.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hypersistence.utils.hibernate.type.MutableDynamicParameterizedType;
+import io.hypersistence.utils.hibernate.type.json.internal.JsonClobJdbcTypeDescriptor;
+import io.hypersistence.utils.hibernate.type.json.internal.JsonJavaTypeDescriptor;
+import io.hypersistence.utils.hibernate.type.util.JsonConfiguration;
+import io.hypersistence.utils.hibernate.type.util.ObjectMapperWrapper;
+
+import java.lang.reflect.Type;
+import java.sql.Clob;
+
+/**
+ * <p>
+ * Maps any given Java object on a JSON column type that is managed via {@link java.sql.PreparedStatement#setClob(int, Clob)} at JDBC Driver level.
+ * </p>
+ * <p>
+ * If you are using <strong>Oracle</strong>, you can use this {@link JsonClobType} to map a {@code CLOB} column type storing JSON.
+ * </p>
+ * <p>
+ * For more details about how to use it, check out <a href="https://vladmihalcea.com/oracle-json-jpa-hibernate/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ * </p>
+ * <p>
+ * If you want to use a more portable Hibernate <code>Type</code> that can work on <strong>Oracle</strong>, <strong>SQL Server</strong>, <strong>PostgreSQL</strong>, <strong>MySQL</strong>, or <strong>H2</strong> without any configuration changes, then you should use the {@link JsonType} instead.
+ * </p>
+ *
+ * @author Vlad Mihalcea
+ */
+public class JsonClobType extends MutableDynamicParameterizedType<Object, JsonClobJdbcTypeDescriptor, JsonJavaTypeDescriptor> {
+
+    public static final JsonClobType INSTANCE = new JsonClobType();
+
+    public JsonClobType() {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(JsonConfiguration.INSTANCE.getObjectMapperWrapper())
+        );
+    }
+
+    public JsonClobType(Type javaType) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(JsonConfiguration.INSTANCE.getObjectMapperWrapper(), javaType)
+        );
+    }
+
+    public JsonClobType(JsonConfiguration configuration) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(configuration.getObjectMapperWrapper())
+        );
+    }
+
+    public JsonClobType(org.hibernate.type.spi.TypeBootstrapContext typeBootstrapContext) {
+        this(new JsonConfiguration(typeBootstrapContext.getConfigurationSettings()));
+    }
+
+    public JsonClobType(ObjectMapper objectMapper) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(new ObjectMapperWrapper(objectMapper))
+        );
+    }
+
+    public JsonClobType(ObjectMapperWrapper objectMapperWrapper) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(objectMapperWrapper)
+        );
+    }
+
+    public JsonClobType(ObjectMapper objectMapper, Type javaType) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(new ObjectMapperWrapper(objectMapper), javaType)
+        );
+    }
+
+    public JsonClobType(ObjectMapperWrapper objectMapperWrapper, Type javaType) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(objectMapperWrapper, javaType)
+        );
+    }
+
+    public String getName() {
+        return "jsonb-clob";
+    }
+}

--- a/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonClobJdbcTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonClobJdbcTypeDescriptor.java
@@ -1,0 +1,32 @@
+package io.hypersistence.utils.hibernate.type.json.internal;
+
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
+
+/**
+ * @author Vlad Mihalcea
+ * @author Andreas Gebhardt
+ */
+public class JsonClobJdbcTypeDescriptor extends AbstractJsonJdbcTypeDescriptor {
+
+    public static final JsonClobJdbcTypeDescriptor INSTANCE = new JsonClobJdbcTypeDescriptor();
+
+    private final ClobJdbcType clobTypeDescriptor = ClobJdbcType.DEFAULT;
+
+    @Override
+    public int getJdbcTypeCode() {
+        return clobTypeDescriptor.getJdbcTypeCode();
+    }
+
+    @Override
+    public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
+        return clobTypeDescriptor.getBinder(javaType);
+    }
+
+    @Override
+    public <X> ValueExtractor<X> getExtractor(JavaType<X> javaType) {
+        return clobTypeDescriptor.getExtractor(javaType);
+    }
+}

--- a/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJdbcTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-60/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJdbcTypeDescriptor.java
@@ -93,8 +93,9 @@ public class JsonJdbcTypeDescriptor extends AbstractJsonJdbcTypeDescriptor imple
                                 case "json":
                                     return JsonBytesJdbcTypeDescriptor.of(Database.ORACLE);
                                 case "blob":
-                                case "clob":
                                     return JsonBlobJdbcTypeDescriptor.INSTANCE;
+                                case "clob":
+                                    return JsonClobJdbcTypeDescriptor.INSTANCE;
                                 case "varchar2":
                                 case "nvarchar2":
                                     return JsonStringJdbcTypeDescriptor.INSTANCE;

--- a/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/hibernate/type/json/OracleJsonClobTypeTest.java
+++ b/hypersistence-utils-hibernate-60/src/test/java/io/hypersistence/utils/hibernate/type/json/OracleJsonClobTypeTest.java
@@ -1,0 +1,180 @@
+package io.hypersistence.utils.hibernate.type.json;
+
+import io.hypersistence.utils.hibernate.type.json.internal.JacksonUtil;
+import io.hypersistence.utils.hibernate.type.model.BaseEntity;
+import io.hypersistence.utils.hibernate.type.model.Location;
+import io.hypersistence.utils.hibernate.type.model.Ticket;
+import io.hypersistence.utils.hibernate.util.AbstractOracleIntegrationTest;
+import io.hypersistence.utils.jdbc.validator.SQLStatementCountValidator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import net.ttddyy.dsproxy.QueryCount;
+import net.ttddyy.dsproxy.QueryCountHolder;
+import org.hibernate.Session;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Vlad Mihalcea
+ * @author Andreas Gebhardt
+ */
+public class OracleJsonClobTypeTest extends AbstractOracleIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+                Event.class,
+                Participant.class
+        };
+    }
+
+    private Event _event;
+
+    private Participant _participant;
+
+    @Override
+    protected void afterInit() {
+        executeStatement("ALTER TABLE event MOVE LOB (location) STORE AS (CACHE)");
+        executeStatement("ALTER TABLE participant MOVE LOB (ticket, metadata) STORE AS (CACHE)");
+
+        doInJPA(entityManager -> {
+            Event nullEvent = new Event();
+            nullEvent.setId(0L);
+            entityManager.persist(nullEvent);
+
+            Location location = new Location();
+            location.setCountry("Romania");
+            location.setCity("Cluj-Napoca");
+
+            Event event = new Event();
+            event.setId(1L);
+            event.setLocation(location);
+            entityManager.persist(event);
+
+            Ticket ticket = new Ticket();
+            ticket.setPrice(12.34d);
+            ticket.setRegistrationCode("ABC123");
+
+            Participant participant = new Participant();
+            participant.setId(1L);
+            participant.setTicket(ticket);
+            participant.setEvent(event);
+            participant.setMetadata(JacksonUtil.toString(location));
+
+            entityManager.persist(participant);
+
+            _event = event;
+            _participant = participant;
+        });
+    }
+
+    @Test
+    public void testLoad() {
+        SQLStatementCountValidator.reset();
+
+        doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+            assertEquals("Romania", event.getLocation().getCountry());
+            assertEquals("Cluj-Napoca", event.getLocation().getCity());
+        });
+
+        SQLStatementCountValidator.assertTotalCount(1);
+        SQLStatementCountValidator.assertSelectCount(1);
+        SQLStatementCountValidator.assertUpdateCount(0);
+    }
+
+    @Test
+    public void test() {
+        doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+            assertEquals("Cluj-Napoca", event.getLocation().getCity());
+
+            Participant participant = entityManager.find(Participant.class, _participant.getId());
+            assertEquals("ABC123", participant.getTicket().getRegistrationCode());
+
+            event.getLocation().setCity("Constanța");
+            assertEquals(Integer.valueOf(0), event.getVersion());
+            entityManager.flush();
+            assertEquals(Integer.valueOf(1), event.getVersion());
+        });
+
+        doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+            event.getLocation().setCity(null);
+            assertEquals(Integer.valueOf(1), event.getVersion());
+            entityManager.flush();
+            assertEquals(Integer.valueOf(2), event.getVersion());
+        });
+
+        doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+            event.setLocation(null);
+            assertEquals(Integer.valueOf(2), event.getVersion());
+            entityManager.flush();
+            assertEquals(Integer.valueOf(3), event.getVersion());
+        });
+    }
+
+    @Entity(name = "Event")
+    @Table(name = "event")
+    public static class Event extends BaseEntity {
+
+        @Type(JsonClobType.class)
+        @Column(columnDefinition = "CLOB")
+        private Location location;
+
+        public Location getLocation() {
+            return location;
+        }
+
+        public void setLocation(Location location) {
+            this.location = location;
+        }
+    }
+
+    @Entity(name = "Participant")
+    @Table(name = "participant")
+    public static class Participant extends BaseEntity {
+
+        @Type(JsonClobType.class)
+        @Column(columnDefinition = "CLOB")
+        private Ticket ticket;
+
+        @ManyToOne
+        private Event event;
+
+        @Type(JsonClobType.class)
+        @Column(name = "metadata", columnDefinition = "CLOB")
+        private String metadata;
+
+        public Ticket getTicket() {
+            return ticket;
+        }
+
+        public void setTicket(Ticket ticket) {
+            this.ticket = ticket;
+        }
+
+        public Event getEvent() {
+            return event;
+        }
+
+        public void setEvent(Event event) {
+            this.event = event;
+        }
+
+        public String getMetadata() {
+            return metadata;
+        }
+
+        public void setMetadata(String metadata) {
+            this.metadata = metadata;
+        }
+    }
+}

--- a/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonClobType.java
+++ b/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonClobType.java
@@ -1,0 +1,96 @@
+package io.hypersistence.utils.hibernate.type.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hypersistence.utils.hibernate.type.MutableDynamicParameterizedType;
+import io.hypersistence.utils.hibernate.type.json.internal.JsonClobJdbcTypeDescriptor;
+import io.hypersistence.utils.hibernate.type.json.internal.JsonJavaTypeDescriptor;
+import io.hypersistence.utils.hibernate.type.util.JsonConfiguration;
+import io.hypersistence.utils.hibernate.type.util.ObjectMapperWrapper;
+
+import java.lang.reflect.Type;
+import java.sql.Clob;
+
+/**
+ * <p>
+ * Maps any given Java object on a JSON column type that is managed via {@link java.sql.PreparedStatement#setClob(int, Clob)} at JDBC Driver level.
+ * </p>
+ * <p>
+ * If you are using <strong>Oracle</strong>, you can use this {@link JsonClobType} to map a {@code CLOB} column type storing JSON.
+ * </p>
+ * <p>
+ * For more details about how to use it, check out <a href="https://vladmihalcea.com/oracle-json-jpa-hibernate/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ * </p>
+ * <p>
+ * If you want to use a more portable Hibernate <code>Type</code> that can work on <strong>Oracle</strong>, <strong>SQL Server</strong>, <strong>PostgreSQL</strong>, <strong>MySQL</strong>, or <strong>H2</strong> without any configuration changes, then you should use the {@link JsonType} instead.
+ * </p>
+ *
+ * @author Vlad Mihalcea
+ */
+public class JsonClobType extends MutableDynamicParameterizedType<Object, JsonClobJdbcTypeDescriptor, JsonJavaTypeDescriptor> {
+
+    public static final JsonClobType INSTANCE = new JsonClobType();
+
+    public JsonClobType() {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(JsonConfiguration.INSTANCE.getObjectMapperWrapper())
+        );
+    }
+
+    public JsonClobType(Type javaType) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(JsonConfiguration.INSTANCE.getObjectMapperWrapper(), javaType)
+        );
+    }
+
+    public JsonClobType(JsonConfiguration configuration) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(configuration.getObjectMapperWrapper())
+        );
+    }
+
+    public JsonClobType(org.hibernate.type.spi.TypeBootstrapContext typeBootstrapContext) {
+        this(new JsonConfiguration(typeBootstrapContext.getConfigurationSettings()));
+    }
+
+    public JsonClobType(ObjectMapper objectMapper) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(new ObjectMapperWrapper(objectMapper))
+        );
+    }
+
+    public JsonClobType(ObjectMapperWrapper objectMapperWrapper) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(objectMapperWrapper)
+        );
+    }
+
+    public JsonClobType(ObjectMapper objectMapper, Type javaType) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(new ObjectMapperWrapper(objectMapper), javaType)
+        );
+    }
+
+    public JsonClobType(ObjectMapperWrapper objectMapperWrapper, Type javaType) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(objectMapperWrapper, javaType)
+        );
+    }
+
+    public String getName() {
+        return "jsonb-clob";
+    }
+}

--- a/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonClobJdbcTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonClobJdbcTypeDescriptor.java
@@ -1,0 +1,32 @@
+package io.hypersistence.utils.hibernate.type.json.internal;
+
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
+
+/**
+ * @author Vlad Mihalcea
+ * @author Andreas Gebhardt
+ */
+public class JsonClobJdbcTypeDescriptor extends AbstractJsonJdbcTypeDescriptor {
+
+    public static final JsonClobJdbcTypeDescriptor INSTANCE = new JsonClobJdbcTypeDescriptor();
+
+    private final ClobJdbcType clobTypeDescriptor = ClobJdbcType.DEFAULT;
+
+    @Override
+    public int getJdbcTypeCode() {
+        return clobTypeDescriptor.getJdbcTypeCode();
+    }
+
+    @Override
+    public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
+        return clobTypeDescriptor.getBinder(javaType);
+    }
+
+    @Override
+    public <X> ValueExtractor<X> getExtractor(JavaType<X> javaType) {
+        return clobTypeDescriptor.getExtractor(javaType);
+    }
+}

--- a/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJdbcTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-62/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJdbcTypeDescriptor.java
@@ -93,8 +93,9 @@ public class JsonJdbcTypeDescriptor extends AbstractJsonJdbcTypeDescriptor imple
                                 case "json":
                                     return JsonBytesJdbcTypeDescriptor.of(Database.ORACLE);
                                 case "blob":
-                                case "clob":
                                     return JsonBlobJdbcTypeDescriptor.INSTANCE;
+                                case "clob":
+                                    return JsonClobJdbcTypeDescriptor.INSTANCE;
                                 case "varchar2":
                                 case "nvarchar2":
                                     return JsonStringJdbcTypeDescriptor.INSTANCE;

--- a/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/type/json/OracleJsonClobTypeTest.java
+++ b/hypersistence-utils-hibernate-62/src/test/java/io/hypersistence/utils/hibernate/type/json/OracleJsonClobTypeTest.java
@@ -1,0 +1,180 @@
+package io.hypersistence.utils.hibernate.type.json;
+
+import io.hypersistence.utils.hibernate.type.json.internal.JacksonUtil;
+import io.hypersistence.utils.hibernate.type.model.BaseEntity;
+import io.hypersistence.utils.hibernate.type.model.Location;
+import io.hypersistence.utils.hibernate.type.model.Ticket;
+import io.hypersistence.utils.hibernate.util.AbstractOracleIntegrationTest;
+import io.hypersistence.utils.jdbc.validator.SQLStatementCountValidator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import net.ttddyy.dsproxy.QueryCount;
+import net.ttddyy.dsproxy.QueryCountHolder;
+import org.hibernate.Session;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Vlad Mihalcea
+ * @author Andreas Gebhardt
+ */
+public class OracleJsonClobTypeTest extends AbstractOracleIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+                Event.class,
+                Participant.class
+        };
+    }
+
+    private Event _event;
+
+    private Participant _participant;
+
+    @Override
+    protected void afterInit() {
+        executeStatement("ALTER TABLE event MOVE LOB (location) STORE AS (CACHE)");
+        executeStatement("ALTER TABLE participant MOVE LOB (ticket, metadata) STORE AS (CACHE)");
+
+        doInJPA(entityManager -> {
+            Event nullEvent = new Event();
+            nullEvent.setId(0L);
+            entityManager.persist(nullEvent);
+
+            Location location = new Location();
+            location.setCountry("Romania");
+            location.setCity("Cluj-Napoca");
+
+            Event event = new Event();
+            event.setId(1L);
+            event.setLocation(location);
+            entityManager.persist(event);
+
+            Ticket ticket = new Ticket();
+            ticket.setPrice(12.34d);
+            ticket.setRegistrationCode("ABC123");
+
+            Participant participant = new Participant();
+            participant.setId(1L);
+            participant.setTicket(ticket);
+            participant.setEvent(event);
+            participant.setMetadata(JacksonUtil.toString(location));
+
+            entityManager.persist(participant);
+
+            _event = event;
+            _participant = participant;
+        });
+    }
+
+    @Test
+    public void testLoad() {
+        SQLStatementCountValidator.reset();
+
+        doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+            assertEquals("Romania", event.getLocation().getCountry());
+            assertEquals("Cluj-Napoca", event.getLocation().getCity());
+        });
+
+        SQLStatementCountValidator.assertTotalCount(1);
+        SQLStatementCountValidator.assertSelectCount(1);
+        SQLStatementCountValidator.assertUpdateCount(0);
+    }
+
+    @Test
+    public void test() {
+        doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+            assertEquals("Cluj-Napoca", event.getLocation().getCity());
+
+            Participant participant = entityManager.find(Participant.class, _participant.getId());
+            assertEquals("ABC123", participant.getTicket().getRegistrationCode());
+
+            event.getLocation().setCity("Constanța");
+            assertEquals(Integer.valueOf(0), event.getVersion());
+            entityManager.flush();
+            assertEquals(Integer.valueOf(1), event.getVersion());
+        });
+
+        doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+            event.getLocation().setCity(null);
+            assertEquals(Integer.valueOf(1), event.getVersion());
+            entityManager.flush();
+            assertEquals(Integer.valueOf(2), event.getVersion());
+        });
+
+        doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+            event.setLocation(null);
+            assertEquals(Integer.valueOf(2), event.getVersion());
+            entityManager.flush();
+            assertEquals(Integer.valueOf(3), event.getVersion());
+        });
+    }
+
+    @Entity(name = "Event")
+    @Table(name = "event")
+    public static class Event extends BaseEntity {
+
+        @Type(JsonClobType.class)
+        @Column(columnDefinition = "CLOB")
+        private Location location;
+
+        public Location getLocation() {
+            return location;
+        }
+
+        public void setLocation(Location location) {
+            this.location = location;
+        }
+    }
+
+    @Entity(name = "Participant")
+    @Table(name = "participant")
+    public static class Participant extends BaseEntity {
+
+        @Type(JsonClobType.class)
+        @Column(columnDefinition = "CLOB")
+        private Ticket ticket;
+
+        @ManyToOne
+        private Event event;
+
+        @Type(JsonClobType.class)
+        @Column(name = "metadata", columnDefinition = "CLOB")
+        private String metadata;
+
+        public Ticket getTicket() {
+            return ticket;
+        }
+
+        public void setTicket(Ticket ticket) {
+            this.ticket = ticket;
+        }
+
+        public Event getEvent() {
+            return event;
+        }
+
+        public void setEvent(Event event) {
+            this.event = event;
+        }
+
+        public String getMetadata() {
+            return metadata;
+        }
+
+        public void setMetadata(String metadata) {
+            this.metadata = metadata;
+        }
+    }
+}

--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonClobType.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonClobType.java
@@ -1,0 +1,96 @@
+package io.hypersistence.utils.hibernate.type.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hypersistence.utils.hibernate.type.MutableDynamicParameterizedType;
+import io.hypersistence.utils.hibernate.type.json.internal.JsonClobJdbcTypeDescriptor;
+import io.hypersistence.utils.hibernate.type.json.internal.JsonJavaTypeDescriptor;
+import io.hypersistence.utils.hibernate.type.util.JsonConfiguration;
+import io.hypersistence.utils.hibernate.type.util.ObjectMapperWrapper;
+
+import java.lang.reflect.Type;
+import java.sql.Clob;
+
+/**
+ * <p>
+ * Maps any given Java object on a JSON column type that is managed via {@link java.sql.PreparedStatement#setClob(int, Clob)} at JDBC Driver level.
+ * </p>
+ * <p>
+ * If you are using <strong>Oracle</strong>, you can use this {@link JsonClobType} to map a {@code CLOB} column type storing JSON.
+ * </p>
+ * <p>
+ * For more details about how to use it, check out <a href="https://vladmihalcea.com/oracle-json-jpa-hibernate/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ * </p>
+ * <p>
+ * If you want to use a more portable Hibernate <code>Type</code> that can work on <strong>Oracle</strong>, <strong>SQL Server</strong>, <strong>PostgreSQL</strong>, <strong>MySQL</strong>, or <strong>H2</strong> without any configuration changes, then you should use the {@link JsonType} instead.
+ * </p>
+ *
+ * @author Vlad Mihalcea
+ */
+public class JsonClobType extends MutableDynamicParameterizedType<Object, JsonClobJdbcTypeDescriptor, JsonJavaTypeDescriptor> {
+
+    public static final JsonClobType INSTANCE = new JsonClobType();
+
+    public JsonClobType() {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(JsonConfiguration.INSTANCE.getObjectMapperWrapper())
+        );
+    }
+
+    public JsonClobType(Type javaType) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(JsonConfiguration.INSTANCE.getObjectMapperWrapper(), javaType)
+        );
+    }
+
+    public JsonClobType(JsonConfiguration configuration) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(configuration.getObjectMapperWrapper())
+        );
+    }
+
+    public JsonClobType(org.hibernate.type.spi.TypeBootstrapContext typeBootstrapContext) {
+        this(new JsonConfiguration(typeBootstrapContext.getConfigurationSettings()));
+    }
+
+    public JsonClobType(ObjectMapper objectMapper) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(new ObjectMapperWrapper(objectMapper))
+        );
+    }
+
+    public JsonClobType(ObjectMapperWrapper objectMapperWrapper) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(objectMapperWrapper)
+        );
+    }
+
+    public JsonClobType(ObjectMapper objectMapper, Type javaType) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(new ObjectMapperWrapper(objectMapper), javaType)
+        );
+    }
+
+    public JsonClobType(ObjectMapperWrapper objectMapperWrapper, Type javaType) {
+        super(
+            Object.class,
+            JsonClobJdbcTypeDescriptor.INSTANCE,
+            new JsonJavaTypeDescriptor(objectMapperWrapper, javaType)
+        );
+    }
+
+    public String getName() {
+        return "jsonb-clob";
+    }
+}

--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonClobJdbcTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonClobJdbcTypeDescriptor.java
@@ -1,0 +1,32 @@
+package io.hypersistence.utils.hibernate.type.json.internal;
+
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
+
+/**
+ * @author Vlad Mihalcea
+ * @author Andreas Gebhardt
+ */
+public class JsonClobJdbcTypeDescriptor extends AbstractJsonJdbcTypeDescriptor {
+
+    public static final JsonClobJdbcTypeDescriptor INSTANCE = new JsonClobJdbcTypeDescriptor();
+
+    private final ClobJdbcType clobTypeDescriptor = ClobJdbcType.DEFAULT;
+
+    @Override
+    public int getJdbcTypeCode() {
+        return clobTypeDescriptor.getJdbcTypeCode();
+    }
+
+    @Override
+    public <X> ValueBinder<X> getBinder(JavaType<X> javaType) {
+        return clobTypeDescriptor.getBinder(javaType);
+    }
+
+    @Override
+    public <X> ValueExtractor<X> getExtractor(JavaType<X> javaType) {
+        return clobTypeDescriptor.getExtractor(javaType);
+    }
+}

--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJdbcTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJdbcTypeDescriptor.java
@@ -93,8 +93,9 @@ public class JsonJdbcTypeDescriptor extends AbstractJsonJdbcTypeDescriptor imple
                                 case "json":
                                     return JsonBytesJdbcTypeDescriptor.of(Database.ORACLE);
                                 case "blob":
-                                case "clob":
                                     return JsonBlobJdbcTypeDescriptor.INSTANCE;
+                                case "clob":
+                                    return JsonClobJdbcTypeDescriptor.INSTANCE;
                                 case "varchar2":
                                 case "nvarchar2":
                                     return JsonStringJdbcTypeDescriptor.INSTANCE;

--- a/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/type/json/OracleJsonClobTypeTest.java
+++ b/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/type/json/OracleJsonClobTypeTest.java
@@ -1,0 +1,180 @@
+package io.hypersistence.utils.hibernate.type.json;
+
+import io.hypersistence.utils.hibernate.type.json.internal.JacksonUtil;
+import io.hypersistence.utils.hibernate.type.model.BaseEntity;
+import io.hypersistence.utils.hibernate.type.model.Location;
+import io.hypersistence.utils.hibernate.type.model.Ticket;
+import io.hypersistence.utils.hibernate.util.AbstractOracleIntegrationTest;
+import io.hypersistence.utils.jdbc.validator.SQLStatementCountValidator;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import net.ttddyy.dsproxy.QueryCount;
+import net.ttddyy.dsproxy.QueryCountHolder;
+import org.hibernate.Session;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Vlad Mihalcea
+ * @author Andreas Gebhardt
+ */
+public class OracleJsonClobTypeTest extends AbstractOracleIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+                Event.class,
+                Participant.class
+        };
+    }
+
+    private Event _event;
+
+    private Participant _participant;
+
+    @Override
+    protected void afterInit() {
+        executeStatement("ALTER TABLE event MOVE LOB (location) STORE AS (CACHE)");
+        executeStatement("ALTER TABLE participant MOVE LOB (ticket, metadata) STORE AS (CACHE)");
+
+        doInJPA(entityManager -> {
+            Event nullEvent = new Event();
+            nullEvent.setId(0L);
+            entityManager.persist(nullEvent);
+
+            Location location = new Location();
+            location.setCountry("Romania");
+            location.setCity("Cluj-Napoca");
+
+            Event event = new Event();
+            event.setId(1L);
+            event.setLocation(location);
+            entityManager.persist(event);
+
+            Ticket ticket = new Ticket();
+            ticket.setPrice(12.34d);
+            ticket.setRegistrationCode("ABC123");
+
+            Participant participant = new Participant();
+            participant.setId(1L);
+            participant.setTicket(ticket);
+            participant.setEvent(event);
+            participant.setMetadata(JacksonUtil.toString(location));
+
+            entityManager.persist(participant);
+
+            _event = event;
+            _participant = participant;
+        });
+    }
+
+    @Test
+    public void testLoad() {
+        SQLStatementCountValidator.reset();
+
+        doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+            assertEquals("Romania", event.getLocation().getCountry());
+            assertEquals("Cluj-Napoca", event.getLocation().getCity());
+        });
+
+        SQLStatementCountValidator.assertTotalCount(1);
+        SQLStatementCountValidator.assertSelectCount(1);
+        SQLStatementCountValidator.assertUpdateCount(0);
+    }
+
+    @Test
+    public void test() {
+        doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+            assertEquals("Cluj-Napoca", event.getLocation().getCity());
+
+            Participant participant = entityManager.find(Participant.class, _participant.getId());
+            assertEquals("ABC123", participant.getTicket().getRegistrationCode());
+
+            event.getLocation().setCity("Constanța");
+            assertEquals(Integer.valueOf(0), event.getVersion());
+            entityManager.flush();
+            assertEquals(Integer.valueOf(1), event.getVersion());
+        });
+
+        doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+            event.getLocation().setCity(null);
+            assertEquals(Integer.valueOf(1), event.getVersion());
+            entityManager.flush();
+            assertEquals(Integer.valueOf(2), event.getVersion());
+        });
+
+        doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+            event.setLocation(null);
+            assertEquals(Integer.valueOf(2), event.getVersion());
+            entityManager.flush();
+            assertEquals(Integer.valueOf(3), event.getVersion());
+        });
+    }
+
+    @Entity(name = "Event")
+    @Table(name = "event")
+    public static class Event extends BaseEntity {
+
+        @Type(JsonClobType.class)
+        @Column(columnDefinition = "CLOB")
+        private Location location;
+
+        public Location getLocation() {
+            return location;
+        }
+
+        public void setLocation(Location location) {
+            this.location = location;
+        }
+    }
+
+    @Entity(name = "Participant")
+    @Table(name = "participant")
+    public static class Participant extends BaseEntity {
+
+        @Type(JsonClobType.class)
+        @Column(columnDefinition = "CLOB")
+        private Ticket ticket;
+
+        @ManyToOne
+        private Event event;
+
+        @Type(JsonClobType.class)
+        @Column(name = "metadata", columnDefinition = "CLOB")
+        private String metadata;
+
+        public Ticket getTicket() {
+            return ticket;
+        }
+
+        public void setTicket(Ticket ticket) {
+            this.ticket = ticket;
+        }
+
+        public Event getEvent() {
+            return event;
+        }
+
+        public void setEvent(Event event) {
+            this.event = event;
+        }
+
+        public String getMetadata() {
+            return metadata;
+        }
+
+        public void setMetadata(String metadata) {
+            this.metadata = metadata;
+        }
+    }
+}

--- a/hypersistence-utils-hibernate-63/src/test/resources/logback-test.xml
+++ b/hypersistence-utils-hibernate-63/src/test/resources/logback-test.xml
@@ -19,5 +19,10 @@
         <appender-ref ref="console"/>
     </root>
 
+    <logger name="org.testcontainers" level="INFO"/>
+    <!-- The following logger can be used for containers logs since 1.18.0 -->
+    <logger name="tc" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
 
 </configuration>


### PR DESCRIPTION
Using 

```java
@Type(JsonType::class)
@Column(columnDefinition = "clob")
```

fails because `java.sql.Blob` is not assignable from instance of `java.sql.Clob` in https://github.com/vladmihalcea/hypersistence-utils/blob/bbb27c4417d3809c9bfe0ca44e6b8f52710a2d87/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/JsonJavaTypeDescriptor.java#L166-L194

Also `public <X> X unwrap(Object value, Class<X> type, WrapperOptions options) ` fails.
