### PR TITLE
fix: allow pg range works in aot mode

### DIFF
--- a/hypersistence-utils-hibernate-63/src/main/resources/META-INF/native-image/io.hypersistence/hypersistence-utils-hibernate-63/reflect-config.json
+++ b/hypersistence-utils-hibernate-63/src/main/resources/META-INF/native-image/io.hypersistence/hypersistence-utils-hibernate-63/reflect-config.json
@@ -8,15 +8,19 @@
       },
       {
         "name": "setType",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
+        "parameterTypes": ["java.lang.String"]
       },
       {
         "name": "setValue",
-        "parameterTypes": [
-          "java.lang.String"
-        ]
+        "parameterTypes": ["java.lang.String"]
+      },
+      {
+        "name": "getType",
+        "parameterTypes": []
+      },
+      {
+        "name": "getValue",
+        "parameterTypes": []
       }
     ]
   }


### PR DESCRIPTION
https://github.com/vladmihalcea/hypersistence-utils/blob/d0184894007577f58f4795f16453d6434455b845/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/range/PostgreSQLRangeType.java#L72

`PostgreSQLRangeType` invoke `PGobject#getType`, `PGobject#getValue` via reflection.

```
org.postgresql.util.PGobject.getValue(): java.lang.IllegalArgumentException: java.lang.NoSuchMethodException: org.postgresql.util.PGobject.getValue()
	at io.hypersistence.utils.common.ReflectionUtils.handleException(ReflectionUtils.java:721)
	at io.hypersistence.utils.common.ReflectionUtils.getMethod(ReflectionUtils.java:265)
	at io.hypersistence.utils.common.ReflectionUtils.getMethod(ReflectionUtils.java:223)
	at io.hypersistence.utils.common.ReflectionUtils.getGetter(ReflectionUtils.java:366)
	at io.hypersistence.utils.common.ReflectionUtils.invokeGetter(ReflectionUtils.java:432)
	at io.hypersistence.utils.hibernate.type.range.PostgreSQLRangeType.get(PostgreSQLRangeType.java:73)
	at io.hypersistence.utils.hibernate.type.range.PostgreSQLRangeType.get(PostgreSQLRangeType.java:45)
	at io.hypersistence.utils.hibernate.type.ImmutableType.nullSafeGet(ImmutableType.java:99)
	at org.hibernate.type.internal.UserTypeSqlTypeAdapter$ValueExtractorImpl.extract(UserTypeSqlTypeAdapter.java:109)
	at org.hibernate.sql.results.jdbc.internal.JdbcValuesResultSetImpl.getCurrentRowValue(JdbcValuesResultSetImpl.java:387)
	at org.hibernate.sql.results.internal.RowProcessingStateStandardImpl.getJdbcValue(RowProcessingStateStandardImpl.java:152)
	at org.hibernate.sql.results.graph.basic.BasicResultAssembler.extractRawValue(BasicResultAssembler.java:54)
	at org.hibernate.sql.results.graph.basic.BasicResultAssembler.assemble(BasicResultAssembler.java:60)
	at org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.extractConcreteTypeStateValues(EntityInitializerImpl.java:1607)
	at org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.initializeEntityInstance(EntityInitializerImpl.java:1333)
	at org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.initializeInstance(EntityInitializerImpl.java:1312)
	at org.hibernate.sql.results.graph.entity.internal.EntityInitializerImpl.initializeInstance(EntityInitializerImpl.java:97)
	at org.hibernate.sql.results.internal.StandardRowReader.coordinateInitializers(StandardRowReader.java:244)
	at org.hibernate.sql.results.internal.StandardRowReader.readRow(StandardRowReader.java:141)
	at org.hibernate.sql.results.spi.ListResultsConsumer.read(ListResultsConsumer.java:249)
	at org.hibernate.sql.results.spi.ListResultsConsumer.consume(ListResultsConsumer.java:201)
	at org.hibernate.sql.results.spi.ListResultsConsumer.consume(ListResultsConsumer.java:35)
	at org.hibernate.sql.exec.internal.JdbcSelectExecutorStandardImpl.doExecuteQuery(JdbcSelectExecutorStandardImpl.java:224)
	at org.hibernate.sql.exec.internal.JdbcSelectExecutorStandardImpl.executeQuery(JdbcSelectExecutorStandardImpl.java:102)
	at org.hibernate.sql.exec.spi.JdbcSelectExecutor.executeQuery(JdbcSelectExecutor.java:91)
	at org.hibernate.sql.exec.spi.JdbcSelectExecutor.list(JdbcSelectExecutor.java:165)
	at org.hibernate.query.sqm.internal.ConcreteSqmSelectQueryPlan.lambda$new$1(ConcreteSqmSelectQueryPlan.java:152)
	at org.hibernate.query.sqm.internal.ConcreteSqmSelectQueryPlan.withCacheableSqmInterpretation(ConcreteSqmSelectQueryPlan.java:442)
	at org.hibernate.query.sqm.internal.ConcreteSqmSelectQueryPlan.performList(ConcreteSqmSelectQueryPlan.java:362)
	at org.hibernate.query.sqm.internal.SqmSelectionQueryImpl.doList(SqmSelectionQueryImpl.java:390)
	at org.hibernate.query.spi.AbstractSelectionQuery.list(AbstractSelectionQuery.java:143)
	at org.hibernate.query.SelectionQuery.getResultList(SelectionQuery.java:124)
	...
	at org.jboss.resteasy.reactive.server.handlers.InvocationHandler.handle(InvocationHandler.java:29)
	at io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext.invokeHandler(QuarkusResteasyReactiveRequestContext.java:141)
	at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:147)
	at io.quarkus.virtual.threads.ContextPreservingExecutorService$ContextPreservingRunnable.run(ContextPreservingExecutorService.java:45)
	at java.base@21.0.7/java.util.concurrent.ThreadPerTaskExecutor$TaskRunner.run(ThreadPerTaskExecutor.java:314)
	at java.base@21.0.7/java.lang.Thread.runWith(Thread.java:1596)
	at java.base@21.0.7/java.lang.VirtualThread.run(VirtualThread.java:329)
	at java.base@21.0.7/java.lang.VirtualThread$VThreadContinuation$1.run(VirtualThread.java:209)
Caused by: java.lang.NoSuchMethodException: org.postgresql.util.PGobject.getValue()
	at java.base@21.0.7/java.lang.Class.checkMethod(DynamicHub.java:1078)
	at java.base@21.0.7/java.lang.Class.getDeclaredMethod(DynamicHub.java:1168)
	at io.hypersistence.utils.common.ReflectionUtils.getMethod(ReflectionUtils.java:255)
	... 77 more


```