### PR TITLE
Change `SQLStatementCountMismatchException` to extend `AssertionError`

### DIFF
--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/jdbc/validator/SQLStatementCountMismatchException.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/jdbc/validator/SQLStatementCountMismatchException.java
@@ -7,7 +7,7 @@ package io.hypersistence.utils.jdbc.validator;
  * @author Vlad Mihalcea
  * @since 3.0.2
  */
-public class SQLStatementCountMismatchException extends RuntimeException {
+public class SQLStatementCountMismatchException extends AssertionError {
 
     private final long expected;
     private final long recorded;

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/jdbc/validator/SQLStatementCountMismatchException.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/jdbc/validator/SQLStatementCountMismatchException.java
@@ -7,7 +7,7 @@ package io.hypersistence.utils.jdbc.validator;
  * @author Vlad Mihalcea
  * @since 3.0.2
  */
-public class SQLStatementCountMismatchException extends RuntimeException {
+public class SQLStatementCountMismatchException extends AssertionError {
 
     private final long expected;
     private final long recorded;


### PR DESCRIPTION
Modifies to extend instead of for better integration with test frameworks. This allows test runners to properly identify assertion failures when SQL statement count validation fails. `SQLStatementCountMismatchException``AssertionError``RuntimeException`

The change is backward compatible since is also unchecked and will be caught by existing handlers. `AssertionError``RuntimeException`
